### PR TITLE
Serviceaccount fix and prometheus operator support

### DIFF
--- a/helm/kube-opex-analytics/templates/_helpers.tpl
+++ b/helm/kube-opex-analytics/templates/_helpers.tpl
@@ -50,3 +50,11 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- define "imagePullSecret" }}
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.imageCredentials.registry (printf "%s:%s" .Values.imageCredentials.username .Values.imageCredentials.password | b64enc) | b64enc }}
 {{- end }}
+
+{{- define "kube-opex-analytics.prometheusLabels" -}}
+{{- if .Values.prometheusOperator.enabled }}
+  {{- range $key, $val := .Values.prometheusOperator.labels }}
+{{ $key -}}: {{ $val }}
+  {{- end}}
+{{- end }}
+{{- end -}}

--- a/helm/kube-opex-analytics/templates/deployment.yaml
+++ b/helm/kube-opex-analytics/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         app.kubernetes.io/name: {{ include "kube-opex-analytics.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ include "kube-opex-analytics.fullname" . }}
       restartPolicy: Always
       containers:
         - name: {{ .Chart.Name }}
@@ -60,7 +61,6 @@ spec:
     spec:
       accessModes:
         - ReadWriteOnce
-      storageClassName: standard-disk
       resources:
         requests:
           storage: {{ .Values.dataVolume.capacity }}

--- a/helm/kube-opex-analytics/templates/serviceaccount.yaml
+++ b/helm/kube-opex-analytics/templates/serviceaccount.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kube-opex-analytics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kube-opex-analytics.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kube-opex-analytics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kube-opex-analytics.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kube-opex-analytics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kube-opex-analytics.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kube-opex-analytics.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kube-opex-analytics.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/helm/kube-opex-analytics/templates/servicemonitor.yaml
+++ b/helm/kube-opex-analytics/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.prometheusOperator.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "kube-opex-analytics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kube-opex-analytics.labels" . | nindent 4 }}
+    {{- include "kube-opex-analytics.prometheusLabels" . | nindent 4 }}
+spec:
+  endpoints:
+  - path: /metrics
+    port: http
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+        app: {{ include "kube-opex-analytics.fullname" . }}
+{{- end}}

--- a/helm/kube-opex-analytics/values.yaml
+++ b/helm/kube-opex-analytics/values.yaml
@@ -14,6 +14,11 @@ dataVolume:
   persist: false
   capacity: 4Gi
 
+prometheusOperator:
+  enabled: false
+  labels:
+
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
Added proper RBAC supoort using a serviceaccount just for this and binded to a clusterrole that has the minimum needed permissions. 

Added support to deploy a prometheus servicemonitor for those that use prometheus operator 