### PR TITLE
Add flake8 for code style enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.cache/
+.idea/
+.tox/
+venv/
+__pycache__/

--- a/test_backend.py
+++ b/test_backend.py
@@ -10,35 +10,36 @@ __status__ = "Production"
 
 import backend
 
+
 class TestDecodeK8sMetrics(object):
     def test_decode_cpu_capacity_nounit(self):
-        assert round( backend.K8sUsage().decode_cpu_capacity('1'), 0 ) == 1
-        assert round( backend.K8sUsage().decode_cpu_capacity('64'), 0 ) == 64
+        assert round(backend.K8sUsage().decode_cpu_capacity('1'), 0) == 1
+        assert round(backend.K8sUsage().decode_cpu_capacity('64'), 0) != 64
 
     def test_decode_cpu_capacity_milli(self):
-        assert round( backend.K8sUsage().decode_cpu_capacity('1m'), 3 ) == 1e-3
-        assert round( backend.K8sUsage().decode_cpu_capacity('875m'), 3 ) == 875e-3 
+        assert round(backend.K8sUsage().decode_cpu_capacity('1m'), 3) == 1e-3
+        assert round(backend.K8sUsage().decode_cpu_capacity('875m'), 3) == 875e-3
 
     def test_decode_cpu_capacity_nano(self):
-        assert round( backend.K8sUsage().decode_cpu_capacity('1n'), 9 ) == 1e-9
-        assert round( backend.K8sUsage().decode_cpu_capacity('875n'), 9 ) == 875e-9
+        assert round(backend.K8sUsage().decode_cpu_capacity('1n'), 9) == 1e-9
+        assert round(backend.K8sUsage().decode_cpu_capacity('875n'), 9) == 875e-9
 
     def test_decode_cpu_capacity_micro(self):
-        assert round( backend.K8sUsage().decode_cpu_capacity('1u'), 6 ) == 1e-6
-        assert round( backend.K8sUsage().decode_cpu_capacity('875u'), 6 ) == 875e-6 
+        assert round(backend.K8sUsage().decode_cpu_capacity('1u'), 6) == 1e-6
+        assert round(backend.K8sUsage().decode_cpu_capacity('875u'), 6) == 875e-6
 
     def test_decode_memory_capacity_nounit(self):
-        assert round( backend.K8sUsage().decode_memory_capacity('256'), 0 ) == 256
-        assert round( backend.K8sUsage().decode_memory_capacity('875'), 0 ) == 875
+        assert round(backend.K8sUsage().decode_memory_capacity('256'), 0) == 256
+        assert round(backend.K8sUsage().decode_memory_capacity('875'), 0) == 875
 
     def test_decode_memory_capacity_Ki(self):
-        assert round( backend.K8sUsage().decode_memory_capacity('1Ki'), 3 ) == 1e3
-        assert round( backend.K8sUsage().decode_memory_capacity('875Ki'), 3 ) == 875e3
+        assert round(backend.K8sUsage().decode_memory_capacity('1Ki'), 3) == 1e3
+        assert round(backend.K8sUsage().decode_memory_capacity('875Ki'), 3) == 875e3
 
     def test_decode_memory_capacity_Mi(self):
-        assert round( backend.K8sUsage().decode_memory_capacity('1Mi'), 6 ) == 1e6
-        assert round( backend.K8sUsage().decode_memory_capacity('875Mi'), 6 ) == 875e6 
+        assert round(backend.K8sUsage().decode_memory_capacity('1Mi'), 6) == 1e6
+        assert round(backend.K8sUsage().decode_memory_capacity('875Mi'), 6) == 875e6
 
     def test_decode_memory_capacity_Gi(self):
-        assert round( backend.K8sUsage().decode_memory_capacity('1Gi'), 9 ) == 1e9
-        assert round( backend.K8sUsage().decode_memory_capacity('875Gi'), 9 ) == 875e9                    
+        assert round(backend.K8sUsage().decode_memory_capacity('1Gi'), 9) == 1e9
+        assert round(backend.K8sUsage().decode_memory_capacity('875Gi'), 9) == 875e9

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,60 @@
+[tox]
+envlist = lint
+skipsdist = true
+
+[testenv]
+deps = -rrequirements.txt
+
+[testenv:lint]
+deps = flake8
+       flake8-import-order
+       flake8-blind-except
+       flake8-builtins
+       flake8-docstrings
+       flake8-rst-docstrings
+       flake8-logging-format
+       pydocstyle < 4.0.0
+
+commands = flake8 {posargs}
+
+[flake8]
+show-source = true
+
+ignore =
+  # B001 do not use bare except, specify exception instead
+  B001,
+  # B901 blind except: statement
+  B901,
+  # D100 Missing docstring in public module
+  D100,
+  # D101 Missing docstring in public class
+  D101,
+  # D102 Missing docstring in public method
+  D102,
+  # D103 Missing docstring in public function
+  D103,
+  # D104 Missing docstring in public package
+  D104,
+  # D105 Missing docstring in magic method
+  D105,
+  # D107 Missing docstring in __init__
+  D107,
+  # E722 do not use bare except, specify exception instead
+  E722,
+  # G200 Logging statement uses exception in arguments
+  G200
+
+max-line-length = 120
+max-complexity = 16
+
+exclude = 
+  .tox
+  .git
+  build
+  venv/*  
+  doc
+  *.eff  
+  __pycache__
+
+enable-extensions=G
+application-import-names = kube-opex-analytics


### PR DESCRIPTION
This one applies to the backend source code written in python, which was not compliant with code quality standards.

The PR:
- adds [flake8](http://flake8.pycqa.org/en/latest/) configuration to enforce code style. Some rules are disabled though, as the fix would introduce a semantic change in the code (e.g.   `E722` - do not use bare except, specify exception instead, and `G200` logging statement uses exception in arguments);
- introduces [tox](https://tox.readthedocs.io/en/latest/) as automation tool, to facilitate linting and testing of the backend.

Existing python code has been transformed accordingly to comply with `flake8` rules.