### PR TITLE
Fix date parsing in sort function

### DIFF
--- a/js/frontend.js
+++ b/js/frontend.js
@@ -145,8 +145,8 @@ define(['jquery', 'bootstrap', 'bootswatch',  'd3Selection', 'stackedAreaChart',
 
                 dataset.data.sort(
                     function(data1, data2) {
-                        let ts1 = Date.parse(data1.dateUTC+' GMT')
-                        let ts2 = Date.parse(data2.dateUTC+' GMT')
+                        let ts1 = Date.parse(data1.dateUTC)
+                        let ts2 = Date.parse(data2.dateUTC)
                         if (ts1 < ts2)
                             return -1;
                         if (ts1 > ts2)


### PR DESCRIPTION
The date provided in the field `dateUTC` is formatted according to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601). Hence, there's no need to append a timezone to the string.

```
〉 data1.dateUTC
〈 "2019-08-16T08:55:00Z"

〉 Date.parse(data1.dateUTC)
〈 1565945700000
```

The previous behavior was returning a `NaN` value, which made the sort ineffective.

```
〉 Date.parse(data1.dateUTC + ' GMT')
〈 NaN
```