### PR TITLE
Helm chart improvements

### DIFF
--- a/helm/kube-opex-analytics/templates/deployment.yaml
+++ b/helm/kube-opex-analytics/templates/deployment.yaml
@@ -29,8 +29,11 @@ spec:
         runAsUser: {{ .Values.securityContext.uid }}
         fsGroup: {{ .Values.securityContext.gid }}
       serviceAccountName: {{ include "kube-opex-analytics.fullname" . }}
-      restartPolicy: Always          
+      restartPolicy: Always
     {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ include "kube-opex-analytics.imageVersion" . }}"

--- a/helm/kube-opex-analytics/templates/deployment.yaml
+++ b/helm/kube-opex-analytics/templates/deployment.yaml
@@ -59,10 +59,15 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-{{- if .Values.dataVolume.persist }}
           volumeMounts:
             - mountPath: /data/
               name: data-vol
+            - mountPath: /koa/static/data/
+              name: static-data-vol
+      volumes:
+      - name: static-data-vol
+        emptyDir: {}
+{{- if .Values.dataVolume.persist }}
   volumeClaimTemplates:
   - metadata:
       name: data-vol
@@ -75,6 +80,9 @@ spec:
       resources:
         requests:
           storage: {{ .Values.dataVolume.capacity }}
+{{- else }}
+      - name: data-vol
+        emptyDir: {}
 {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/kube-opex-analytics/templates/deployment.yaml
+++ b/helm/kube-opex-analytics/templates/deployment.yaml
@@ -28,9 +28,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.uid }}
         fsGroup: {{ .Values.securityContext.gid }}
+    {{- end }}
       serviceAccountName: {{ include "kube-opex-analytics.fullname" . }}
       restartPolicy: Always
-    {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/helm/kube-opex-analytics/templates/ingress.yaml
+++ b/helm/kube-opex-analytics/templates/ingress.yaml
@@ -7,9 +7,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kube-opex-analytics.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml . | trim | nindent 4 }}
   {{- end }}
 spec:
 {{- if .Values.ingress.tls }}

--- a/helm/kube-opex-analytics/values.yaml
+++ b/helm/kube-opex-analytics/values.yaml
@@ -44,6 +44,8 @@ service:
 
 ingress:
   enabled: false
+  annotations: {}
+  labels: {}
   hosts:
     - host: kube-opex-analytics.local
       paths: []

--- a/helm/kube-opex-analytics/values.yaml
+++ b/helm/kube-opex-analytics/values.yaml
@@ -48,16 +48,18 @@ ingress:
     - host: kube-opex-analytics.local
       paths: []
 # uncomment the following lines and ajust the values to enable TLS
-  # tls: 
+  # tls:
   #  - secretName: kube-opex-analytics-tls
   #    hosts:
   #      - kube-opex-analytics.local
 
+# priorityClassName: default
+
 resources: {}
 # No resource requests not limits is specified by default.
-# We leave this as a conscious choice for the user, as this increases chances charts run 
-# on environments with little resources, such as Minikube. 
-# If you do want to specify resources, uncomment the following lines, adjust them as necessary, 
+# We leave this as a conscious choice for the user, as this increases chances charts run
+# on environments with little resources, such as Minikube.
+# If you do want to specify resources, uncomment the following lines, adjust them as necessary,
 # and remove the curly braces after 'resources:'.
   # limits:
   #   cpu: 256m


### PR DESCRIPTION
This PR add some improvements/enhancements to the helm chart. 

* Support for custom labels for the ingress manifest
* Support for priorityClassName in the deployment manifest
* Bugfix for `serviceAccountName` and `restartPolicy`, which were guarded by the unrelated securityContext in the deployment manifest

Additionally it adds support for deploying in clusters with a podSecurityPolicy which prohibits writing into the container filesystem layer. Data is always written to `/data`and `/koa/static/data`, so these must be backed by volumes, either with the existing PVC support, or with newly added `emptyDir`. 