### PR TITLE
Update nodeSelector, affinity and toleration location in yaml file

### DIFF
--- a/helm/kube-opex-analytics/templates/deployment.yaml
+++ b/helm/kube-opex-analytics/templates/deployment.yaml
@@ -67,6 +67,18 @@ spec:
       volumes:
       - name: static-data-vol
         emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- if .Values.dataVolume.persist }}
   volumeClaimTemplates:
   - metadata:
@@ -84,15 +96,3 @@ spec:
       - name: data-vol
         emptyDir: {}
 {{- end }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}


### PR DESCRIPTION
Update nodeSelector, affinity and toleration location due bad location in the yaml  file for deployment or StatefulSet objets. It should not be in volumeClaimTemplates section.  

It fix the next error when you try to add affinity. Same apply to Toleration and nodeSelector:
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(StatefulSet.spec.volumeClaimTemplates[0].spec): unknown field "affinity" in io.k8s.api.core.v1.PersistentVolumeClaimSpec