### PR TITLE
added github-actions ecosystem to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,12 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5
+  assignees:
+    - rchakode
+  reviewers:
+    - rchakode


### PR DESCRIPTION
Just add the [dependabot](https://github.com/dependabot) configuration to support automatic management of github actions version updates.