### PR TITLE
feat: add Helm chart CI/CD workflow and GPU capacity tracking

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,53 @@
+name: Helm Chart Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release-chart:
+    name: Release Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Update Chart version
+        run: |
+          sed -i "s/^version:.*/version: ${{ steps.version.outputs.VERSION }}/" manifests/helm/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${{ steps.version.outputs.VERSION }}\"/" manifests/helm/Chart.yaml
+
+      - name: Lint chart
+        run: helm lint manifests/helm
+
+      - name: Package chart
+        run: |
+          helm package manifests/helm -d .helm-packages
+          echo "CHART_PACKAGE=$(ls .helm-packages/*.tgz)" >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push chart to GHCR (OCI)
+        run: |
+          helm push ${{ env.CHART_PACKAGE }} oci://ghcr.io/${{ github.repository_owner }}/charts
+
+      - name: Upload chart to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.CHART_PACKAGE }}
+          generate_release_notes: true

--- a/backend.py
+++ b/backend.py
@@ -466,6 +466,8 @@ class JSONMarshaller(json.JSONEncoder):
                 "gpuUsage": obj.gpuUsage,
                 "gpuMemUsage": obj.gpuMemUsage,
                 "gpuMemFree": obj.gpuMemFree,
+                "gpuCapacity": obj.gpuCapacity,
+                "gpuAllocatable": obj.gpuAllocatable,
             }
         elif isinstance(obj, Pod):
             return {
@@ -584,8 +586,8 @@ class K8sUsage:
                 node.cpuAllocatable = self.decode_capacity(status["allocatable"]["cpu"])
                 node.memCapacity = self.decode_capacity(status["capacity"]["memory"])
                 node.memAllocatable = self.decode_capacity(status["allocatable"]["memory"])
-                node.gpuCPUCapacity = self.decode_capacity(status["capacity"].get("nvidia.com/gpu", 0))
-                node.gpuCPUAllocatable = self.decode_capacity(status["allocatable"].get("nvidia.com/gpu", 0))
+                node.gpuCapacity = self.decode_capacity(status["capacity"].get("nvidia.com/gpu", "0"))
+                node.gpuAllocatable = self.decode_capacity(status["allocatable"].get("nvidia.com/gpu", "0"))
 
                 for _, cond in enumerate(status["conditions"]):
                     node.message = cond["message"]

--- a/backend.py
+++ b/backend.py
@@ -584,6 +584,8 @@ class K8sUsage:
                 node.cpuAllocatable = self.decode_capacity(status["allocatable"]["cpu"])
                 node.memCapacity = self.decode_capacity(status["capacity"]["memory"])
                 node.memAllocatable = self.decode_capacity(status["allocatable"]["memory"])
+                node.gpuCPUCapacity = self.decode_capacity(status["capacity"].get("nvidia.com/gpu", 0))
+                node.gpuCPUAllocatable = self.decode_capacity(status["allocatable"].get("nvidia.com/gpu", 0))
 
                 for _, cond in enumerate(status["conditions"]):
                     node.message = cond["message"]

--- a/js/frontend.js
+++ b/js/frontend.js
@@ -714,13 +714,15 @@ define(['jquery', 'bootstrap', 'bootswatch', 'd3', 'd3Selection'],
             tooltip += '<tr><td>UID</td><td>' + node.id + '</td></tr>';
             tooltip += '<tr><td>Container Runtime</td><td>' + node.containerRuntime + '</td></tr>';
             tooltip += '<tr><td>State</td><td>' + node.state + '</td></tr>';
+            tooltip += '<tr><td>Pods Running</td><td>' + node.podsRunning.length + '</td></tr>';
             tooltip += '<tr><td>CPU</td><td>' + node.cpuCapacity + '</td></tr>';
             tooltip += '<tr><td>&nbsp;&nbsp;Allocatable</td><td>' + computeLoadPercent(node.cpuAllocatable, node.cpuCapacity) + '</td></tr>';
             tooltip += '<tr><td>&nbsp;&nbsp;Usage</td><td>' + computeLoadPercent(node.cpuUsage, node.cpuCapacity) + '</td></tr>';
-            tooltip += '<tr><td>GPU</td><td>' + node.memCapacity + '</td></tr>';
-            tooltip += '<tr><td>Pods Running</td><td>' + node.podsRunning.length + '</td></tr>';
-            tooltip += '<tr><td>GPU</td><td>' + node.gpuCPUCapacity + '</td></tr>';
-            tooltip += '<tr><td>&nbsp;&nbsp;Allocatable</td><td>' + computeLoadPercent(node.gpuCPUAllocatable, node.gpuCPUCapacity) + '</td></tr>';
+            tooltip += '<tr><td>Memory</td><td>' + node.memCapacity + '</td></tr>';
+            tooltip += '<tr><td>&nbsp;&nbsp;Allocatable</td><td>' + computeLoadPercent(node.memAllocatable, node.memAllocatable) + '</td></tr>';
+            tooltip += '<tr><td>&nbsp;&nbsp;Usage</td><td>' + computeLoadPercent(node.memUsage, node.memCapacity) + '</td></tr>';
+            tooltip += '<tr><td>GPU</td><td>' + node.gpuCapacity + '</td></tr>';
+            tooltip += '<tr><td>&nbsp;&nbsp;Allocatable</td><td>' + computeLoadPercent(node.gpuAllocatable, node.gpuCapacity) + '</td></tr>';
             tooltip += '</tbody></table>';
             return tooltip;
         }

--- a/js/frontend.js
+++ b/js/frontend.js
@@ -717,11 +717,10 @@ define(['jquery', 'bootstrap', 'bootswatch', 'd3', 'd3Selection'],
             tooltip += '<tr><td>CPU</td><td>' + node.cpuCapacity + '</td></tr>';
             tooltip += '<tr><td>&nbsp;&nbsp;Allocatable</td><td>' + computeLoadPercent(node.cpuAllocatable, node.cpuCapacity) + '</td></tr>';
             tooltip += '<tr><td>&nbsp;&nbsp;Usage</td><td>' + computeLoadPercent(node.cpuUsage, node.cpuCapacity) + '</td></tr>';
-            tooltip += '<tr><td>Memory</td><td>' + node.memCapacity + '</td></tr>';
-            tooltip += '<tr><td>&nbsp;&nbsp;Allocatable</td><td>' + computeLoadPercent(node.memAllocatable, node.memAllocatable) + '</td></tr>';
-            tooltip += '<tr><td>&nbsp;&nbsp;Usage</td><td>' + computeLoadPercent(node.memUsage, node.memCapacity) + '</td></tr>';
+            tooltip += '<tr><td>GPU</td><td>' + node.memCapacity + '</td></tr>';
             tooltip += '<tr><td>Pods Running</td><td>' + node.podsRunning.length + '</td></tr>';
-
+            tooltip += '<tr><td>GPU</td><td>' + node.gpuCPUCapacity + '</td></tr>';
+            tooltip += '<tr><td>&nbsp;&nbsp;Allocatable</td><td>' + computeLoadPercent(node.gpuCPUAllocatable, node.gpuCPUCapacity) + '</td></tr>';
             tooltip += '</tbody></table>';
             return tooltip;
         }


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated Helm chart releases to GHCR on version tags
- Add GPU capacity and allocatable tracking to node metrics in backend
- Update frontend tooltip to display GPU information for nodes

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test Helm chart release workflow on a version tag push
- [ ] Confirm GPU metrics appear correctly in node tooltips

🤖 Generated with [Claude Code](https://claude.com/claude-code)