### PR TITLE
feat: add KubeLedger MCP server (26.05.0-b1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Release Notes
 
+## v26.05.0-b1
+
+### Highlights
+
+This release introduces the **KubeLedger MCP server** — an optional, read-only [Model Context Protocol](https://modelcontextprotocol.io/) surface that exposes the analytics produced by the backend (`static/data/*.json`) to MCP-aware clients (Claude Desktop, agents, IDEs). It enables clients to generate analyses, rankings, and visualizations that complement — without duplicating — the default web UI. The server never reads RRD databases directly, never writes, and embeds no LLM: it is a descriptive data surface.
+
+This release also ships a **default-on NetworkPolicy** that protects the pod (backend and MCP) at the network layer, replacing the absence of authentication on the MCP transport in v1.
+
+### New features
+
+#### MCP server (optional, opt-in)
+
+- New `mcp_server.py` module distributed in the container image.
+- **Transport**: Streamable HTTP only — single endpoint `/mcp`, the modern MCP transport supported by Claude Desktop, Claude Code, MCP Inspector, and `mcp-remote` proxies. SSE (legacy two-endpoint pattern) and stdio (subprocess) transports are not exposed in v1; KubeLedger's data lives in-cluster and is naturally consumed over HTTP via the pod's `Service`, not by spawning a local subprocess. A future release may reintroduce SSE if a non-trivial deployment proves it useful.
+- Helm: a second container `mcp` is added to the pod when `mcp.enabled=true` (disabled by default), reusing the same image with `command: ["python3", "-u", "./mcp_server.py"]`. The shared `static/data/` volume is mounted **read-only** in the MCP container.
+- Helm: the existing Service is extended with a second named port `mcp` (default `5484`), conditional on `mcp.enabled`. Type stays `ClusterIP` — intra-cluster access only in v1.
+- Configuration: the MCP server resolves its data directory from `KL_MCP_DATA_DIR` / `KOA_MCP_DATA_DIR` (default `./static/data`), consistent with the existing `KL_*`/`KOA_*` convention. Listen address/port via `KL_MCP_LISTEN_HOST` (default `0.0.0.0`) and `KL_MCP_LISTEN_PORT` (default `5484`).
+
+#### NetworkPolicy (default on)
+
+- New template `templates/networkpolicy.yaml` shipped with the chart. Covers **both** the backend and MCP ports, since the MCP server has no authentication in v1 and the policy is the only access-control mechanism.
+- Default: `networkPolicy.enabled=true`, `allowedSources=[]`, `mcpAllowedSources=[]` — **deny-by-default**.
+- **Operator action required** on clusters that enforce NetworkPolicy (e.g. OpenShift with OVN-Kubernetes): set `networkPolicy.allowedSources` (and `mcpAllowedSources` when MCP is enabled) to the legitimate `NetworkPolicyPeer` entries (`podSelector`, `namespaceSelector`, `ipBlock`). Leaving these lists empty filters all ingress traffic to the pod — this is the intended safe failure mode, not a bug.
+- To disable the policy and rely on cluster-level controls instead, set `networkPolicy.enabled=false`.
+
+### Out of scope for v1
+
+- External exposure of the MCP server (OpenShift `Route` / Ingress) and token authentication — the MCP stays in `ClusterIP` for now.
+- LLM calls, predictions, or prescriptive recommendations — the MCP server is purely descriptive.
+
 ## v26.01.1
 
 ### Security fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY css $APP_HOME/css
 COPY js $APP_HOME/js
 COPY static/images $APP_HOME/static/images
 COPY backend.py \
+    mcp_server.py \
     index.html \
     LICENSE \
     NOTICE \

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [Overview](#overview)
 - [Key Features](#key-features)
 - [Quick Start](#quick-start)
+- [MCP Integration (AI Assistant)](#mcp-integration-ai-assistant)
 - [Architecture](#architecture)
 - [Documentation](#documentation)
 - [Configuration](#configuration)
@@ -159,72 +160,181 @@ kubectl port-forward svc/kubeledger 5483:80 -n kubeledger
 # Open http://localhost:5483 in your browser
 ```
 
-## Installation on Local Machine
+## MCP Integration (AI Assistant)
 
-### Install with Docker
+KubeLedger ships with an **optional MCP ([Model Context Protocol](https://modelcontextprotocol.io)) server** that gives MCP-aware AI tools **direct access to the underlying analytics data** — the consolidated CPU, memory and GPU usage that the web UI is built on. MCP is an open standard adopted by a growing ecosystem: Anthropic's Claude Desktop and Claude Code, Google's Gemini CLI, IDE assistants such as Cursor, Windsurf and Cline, the MCP Inspector developer tool, and others.
 
-Requires `kubectl proxy` running locally to provide API access:
+Where the UI renders a fixed set of dashboards, the MCP exposes ten read-only tools that let an AI assistant combine, filter and aggregate this data into **custom rankings, namespace groupings, efficiency assessments, trend comparisons and narrative insights** — analyses the UI does not predefine.
+
+The server itself is **descriptive only**: it never reaches the Kubernetes API or RRD databases, embeds no LLM, and makes no recommendations. It exposes the data; the client provides the reasoning.
+
+Ten tools are available:
+
+| Tool | Purpose |
+|---|---|
+| `list_namespaces` | Discovered namespaces, classified application / system / special |
+| `describe_dataset` | Capabilities: metrics, scales, cost model, freshness |
+| `get_usage` | Usage time series per namespace for a (metric, scale) |
+| `get_top_consumers` | Ranking by usage on a given date |
+| `get_namespace_breakdown` | Proportional breakdown + concentration + cluster overhead |
+| `get_efficiency` | Aggregated `usage / requests` ratio per namespace |
+| `get_timeseries` | Hourly usage series over the last 7 days |
+| `compare_periods` | 14-day aggregate vs. monthly trajectory + trend direction |
+| `get_efficiency_timeseries` | Hourly efficiency factor (`rf`) series |
+| `group_namespaces` | Aggregate namespaces matching a glob pattern |
+
+Each response carries a `metadata` block with cost_model, unit, data window, source file and warnings. See [kubeledger-mcp-spec.md](kubeledger-mcp-spec.md) for the full specification.
+
+### 1. Enable the MCP container at deploy time
+
+The MCP container is **opt-in** — disabled by default. Enable it via the Helm chart:
 
 ```bash
-# Start kubectl proxy in background
-kubectl proxy &
-
-# Run KubeLedger
-docker run -d \
-  --net="host" \
-  --name kubeledger \
-  -v /var/lib/kubeledger:/data \
-  -e KL_DB_LOCATION=/data/db \
-  -e KL_K8S_API_ENDPOINT=http://127.0.0.1:8001 \
-  ghcr.io/realopslabs/kubeledger
+helm upgrade --install kubeledger ./manifests/kubeledger/helm \
+  -n kubeledger \
+  --set mcp.enabled=true
 ```
 
-### Access the Dashboard on Local Machine
+Enabling adds a second container `mcp` to the pod (same image, command `python3 -u ./mcp_server.py`), mounts the `static/data/` volume **read-only**, and adds a named port `mcp` (default `5484`) on the existing Service.
 
-The dashboard is available at http://localhost:5483.
+> **NetworkPolicy.** MCP v1 has no authentication at the tool layer — access control relies entirely on Kubernetes NetworkPolicy. The chart ships a default-deny policy covering both the dashboard and the MCP ports. Declare authorized sources via `networkPolicy.allowedSources` (dashboard) and `networkPolicy.mcpAllowedSources` (MCP); see the documented options and examples in [`manifests/kubeledger/helm/values.yaml`](manifests/kubeledger/helm/values.yaml). To disable the policy entirely and rely on cluster-level controls instead, set `networkPolicy.enabled=false`.
+
+### 2. Reach the MCP service from your workstation
+
+The Service is `ClusterIP` in v1 — external exposure (Route/Ingress) is out of scope. Use `kubectl port-forward` to reach it from your laptop:
+
+```bash
+kubectl port-forward svc/kubeledger 5484:5484 -n kubeledger
+```
+
+Smoke test in another shell:
+
+```bash
+curl -X POST http://localhost:5484/mcp \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
+```
+
+Expected response: HTTP 200 with a JSON-RPC envelope listing the negotiated `protocolVersion` and server capabilities.
+
+### 3. Connect your MCP client
+
+Every MCP-aware client can be pointed at `http://localhost:5484/mcp` (Streamable HTTP transport). Only the configuration file differs. Two common configurations are detailed below; for other clients, consult their respective MCP integration docs and use the same URL.
+
+#### Claude Code (native HTTP)
+
+Create a `.mcp.json` at the root of the project where you'll work, or register globally via `claude mcp add`:
+
+```json
+{
+  "mcpServers": {
+    "kubeledger": {
+      "type": "http",
+      "url": "http://localhost:5484/mcp"
+    }
+  }
+}
+```
+
+Restart Claude Code; the `kubeledger` server appears connected with the 10 tools.
+
+#### Claude Desktop (via `mcp-remote` bridge)
+
+Claude Desktop currently spawns MCP servers as local subprocesses (stdio only). Use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge to relay stdio to HTTP. Edit `claude_desktop_config.json` (at `%APPDATA%\Claude\` on Windows, `~/Library/Application Support/Claude/` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "kubeledger": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote@latest",
+        "http://localhost:5484/mcp",
+        "--transport",
+        "http-only"
+      ]
+    }
+  }
+}
+```
+
+Prerequisite: a working `node` + `npx` on the system `PATH`. After editing, **fully quit Claude Desktop** (system tray → Quit, not just close the window) and relaunch.
+
+#### Other MCP clients
+
+Most clients accept the same `http://localhost:5484/mcp` endpoint with their own configuration syntax. Examples:
+
+- **Gemini CLI** — declare the server in `~/.gemini/settings.json` under `mcpServers` (Google's [MCP integration docs](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/mcp.md)).
+- **Cursor / Windsurf / Cline** — add the server in the IDE's MCP settings, type `streamable-http`, URL `http://localhost:5484/mcp`.
+- **MCP Inspector** — `npx @modelcontextprotocol/inspector`, then connect to `http://localhost:5484/mcp` with transport `Streamable HTTP`.
+
+Clients that only speak stdio can use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge, same pattern as the Claude Desktop example above.
+
+### Example questions to ask the AI
+
+The assistant picks the right tool automatically — ask in plain language:
+
+- *"Which ten namespaces consume the most CPU over the past 14 days, excluding system namespaces?"*
+- *"Compare the monthly CPU trajectory of `openshift-monitoring` against `kube-system`."*
+- *"Identify CPU over-provisioned namespaces — those with a `usage / requests` ratio below 0.5."*
+- *"Show the hourly memory series for the `registry` namespace over the last 7 days, with min/max/mean."*
+- *"What proportion of cluster CPU is consumed by `openshift-*` namespaces today?"*
+
+### Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `connection refused` on port-forward | MCP container not enabled or pod not ready | `helm get values kubeledger` → confirm `mcp.enabled=true`; `kubectl get pods -n kubeledger` |
+| Client using `mcp-remote`: `spawn npx ENOENT` | Node.js not installed or not on PATH | Install Node.js LTS and restart the client |
+| Client using `mcp-remote`: `Server disconnected` shortly after connect | `mcp-remote` probing SSE which is no longer supported | Add `--transport http-only` to the args (see above) |
+| `403 Forbidden` or timeouts from inside the cluster | NetworkPolicy denying the source | Update `networkPolicy.mcpAllowedSources` with your client's selector |
+| All tools return empty data + warnings about missing files | Backend hasn't dumped aggregates yet (first 5–10 min after deploy) | Wait one `dump_analytics` cycle (`KL_POLLING_INTERVAL_SEC`, default 300 s) |
 
 
 ## Architecture
 
 ```
-┌───────────────────┐
-│  Metrics Server   │──┐
-│  (CPU/Memory)     │  │    ┌───────────────────────────────────────┐
-└───────────────────┘  ├───>│         KubeLedger                    │
-┌───────────────────┐  │    │  ┌─────────┐  ┌────────┐  ┌─────────┐ │
-│  DCGM Exporter    │──┘    │  │ Poller  │─>│RRD DBs │─>│ API     │ │
-│  (GPU metrics)    │       │  │ (5 min) │  │        │  │         │ │
-└───────────────────┘       │  └─────────┘  └────────┘  └────┬────┘ │
-                            └────────────────────────────────┼──────┘
-                                                             │
-                            ┌────────────────────────────────┼───────┐
-                            │                                v       │
-                            │  ┌────────────┐    ┌──────────────┐    │
-                            │  │  Web UI    │    │  /metrics    │    │
-                            │  │  (D3.js)   │    │ (Prometheus) │    │
-                            │  └────────────┘    └──────────────┘    │
-                            └────────────────────────────────────────┘
-                                     │                  │
-                                     v                  v
-                              Built-in Dashboards   Grafana/Alerting
+┌─────────────────┐                ┌─────────── KubeLedger Pod ─────────────────────────┐
+│ Metrics Server  │──┐             │  ┌─ container: backend ──────────────────────────┐ │
+│ (CPU / Memory)  │  │             │  │  Poller (5 min) ─> RRD DBs ─> Flask (UI/API)  │ │
+└─────────────────┘  │             │  │                       │                         │ │
+                     ├── poll ────>│  │                       └─> dump_analytics ──┐    │ │
+┌─────────────────┐  │             │  └──────────────────────────────────────────────│────┘ │
+│ DCGM Exporter   │──┘             │                                                 v      │
+│ (GPU metrics)   │                │            shared volume: static/data/*.json (RO from MCP)
+└─────────────────┘                │                                                 │      │
+                                   │  ┌─ container: mcp (opt-in via mcp.enabled) ────┘────┐ │
+                                   │  │  10 read-only tools over Streamable HTTP /mcp   │ │
+                                   │  └─────────────────────────────────────────────────┘ │
+                                   │                                                       │
+                                   │   K8s Service ─── port 80 (http) │ port 5484 (mcp)    │
+                                   └───────────────────┬───────────────┬───────────────────┘
+                                                       v               v
+                                              Web UI / Prometheus   MCP clients (Claude,
+                                                                    Gemini, Cursor, …)
+                                                                    via kubectl port-forward
 ```
 
 **Data Flow:**
-1. Metrics polled every 5 minutes (configurable):
-   - CPU/Memory from Kubernetes Metrics Server
+1. Metrics polled every 5 minutes (configurable via `KL_POLLING_INTERVAL_SEC`):
+   - CPU / Memory from Kubernetes Metrics Server
    - GPU from NVIDIA DCGM Exporter
 2. Metrics are processed and stored in internal lightweight time-series databases (round-robin DBs)
 3. Data is consolidated into hourly, daily, and monthly aggregates
-4. API serves data to the built-in web UI and Prometheus scraper
+4. `dump_analytics` periodically writes the aggregates as JSON files into a shared volume
+5. The Flask API serves the data to the built-in web UI and Prometheus scraper
+6. *(optional)* The MCP container reads the same JSON files **read-only** and exposes them as 10 MCP tools to AI assistants — see [MCP Integration](#mcp-integration-ai-assistant)
 
 ## Documentation
 
 | Topic | Link |
 |-------|------|
 | Installation on Kubernetes and OpenShift | https://kubeledger.io/docs/installation-on-kubernetes-and-openshift/ |
-| Installation on Docker | https://kubeledger.io/docs/installation-on-docker/ |
 | Built-in Dashboards and Charts of KubeLedger | https://kubeledger.io/docs/built-in-dashboards-and-charts/ |
 | Prometheus Exporter and Grafana dashboards | https://kubeledger.io/docs/prometheus-exporter-grafana-dashboard/ |
+| Enable the MCP Server (AI Assistants) | https://kubeledger.io/docs/enable-kubeledger-mcp/ |
 | KubeLedger Configuration Settings | https://kubeledger.io/docs/configuration-settings/ |
 | Design Fundamentals | https://kubeledger.io/docs/design-fundamentals/ |
 

--- a/backend.py
+++ b/backend.py
@@ -21,7 +21,7 @@ import threading
 import time
 import traceback
 import urllib
-from typing import Any, List
+from typing import Any
 
 import flask
 
@@ -53,11 +53,11 @@ def create_directory_if_not_exists(path):
 
 def get_backend_config_env(var_name, default_value=None):
     """Retrieve environment variable, prioritizing KL_ prefix over KOA_ using explicit check."""
-    kl_var = "KL_{}".format(var_name)
+    kl_var = f"KL_{var_name}"
     if kl_var in os.environ:
         return os.environ[kl_var]
 
-    koa_var = "KOA_{}".format(var_name)
+    koa_var = f"KOA_{var_name}"
     if koa_var in os.environ:
         return os.environ[koa_var]
 
@@ -65,15 +65,15 @@ def get_backend_config_env(var_name, default_value=None):
 
 
 class Config:
-    version = "26.01.1"
+    version = "26.05.0-b1"
     db_round_decimals = 6
     db_non_allocatable = "non-allocatable"
     db_billing_hourly_rate = ".billing-hourly-rate"
     static_content_location = "/static"
-    frontend_data_location = ".%s/data" % (static_content_location)
+    frontend_data_location = f".{static_content_location}/data"
     k8s_api_endpoint = get_backend_config_env("K8S_API_ENDPOINT", "http://127.0.0.1:8001")
     k8s_verify_ssl = (lambda v: v.lower() in ("yes", "true"))(get_backend_config_env("K8S_API_VERIFY_SSL", "true"))
-    db_location = get_backend_config_env("DB_LOCATION", ("%s/.kubeledger/db") % os.getenv("HOME", "/tmp"))
+    db_location = get_backend_config_env("DB_LOCATION", ("{}/.kubeledger/db").format(os.getenv("HOME", "/tmp")))
     polling_interval_sec = int(get_backend_config_env("POLLING_INTERVAL_SEC", "300"))
     cost_model = get_backend_config_env("COST_MODEL", "CUMULATIVE_RATIO")
     billing_currency = get_backend_config_env("BILLING_CURRENCY_SYMBOL", "$")
@@ -121,8 +121,9 @@ class Config:
         self.process_cost_model_config()
         create_directory_if_not_exists(self.frontend_data_location)
         cost_model_label, cost_model_unit = self.process_cost_model_config()
-        with open(str("%s/backend.json" % self.frontend_data_location), "w") as fd:
-            fd.write('{"cost_model":"%s", "currency":"%s"}' % (cost_model_label, cost_model_unit))
+        backend_config = {"cost_model": cost_model_label, "currency": cost_model_unit}
+        with open(f"{self.frontend_data_location}/backend.json", "w") as fd:
+            json.dump(backend_config, fd)
 
         # check listener port
         try:
@@ -154,7 +155,7 @@ class Config:
     def load_rbac_auth_token(self):
         """Load the service account token when applicable."""
         try:
-            with open(KOA_CONFIG.k8s_auth_token_file, "r", encoding=None) as rbac_token_file:
+            with open(KOA_CONFIG.k8s_auth_token_file, encoding=None) as rbac_token_file:
                 self.k8s_rbac_auth_token = rbac_token_file.read()
         except Exception:
             self.k8s_rbac_auth_token = "NO_ENV_TOKEN_FILE"
@@ -165,7 +166,7 @@ class Config:
 
     @staticmethod
     def usage_efficiency_db(ns):
-        return "%s%s" % (ns, Config.request_efficiency_db_file_extension())
+        return f"{ns}{Config.request_efficiency_db_file_extension()}"
 
     @staticmethod
     def gpu_db_file_extension():
@@ -173,7 +174,7 @@ class Config:
 
     @staticmethod
     def gpu_metrics_db(ns):
-        return "%s%s" % (ns, Config.gpu_db_file_extension())
+        return f"{ns}{Config.gpu_db_file_extension()}"
 
 
 def configure_logger(debug_enabled):
@@ -300,7 +301,7 @@ def get_node_heatmap_data():
         if not os.path.exists(nodes_file):
             return flask.jsonify({"error": "Nodes data not available", "nodes": []})
 
-        with open(nodes_file, "r") as f:
+        with open(nodes_file) as f:
             nodes_data = json.load(f)
 
         heatmap_data = []
@@ -653,7 +654,7 @@ class K8sUsage:
 
             pod = Pod()
             pod.namespace = item["metadata"]["namespace"]
-            pod.name = "%s.%s" % (item["metadata"]["name"], pod.namespace)
+            pod.name = "{}.{}".format(item["metadata"]["name"], pod.namespace)
             pod.id = item["metadata"]["uid"]
             pod.phase = item["status"]["phase"]
             if "conditions" not in item["status"]:
@@ -706,7 +707,7 @@ class K8sUsage:
         for _, item in enumerate(data_json["items"]):
             if not KOA_CONFIG.allow_namespace(item["metadata"]["namespace"]):
                 continue
-            pod_name = "%s.%s" % (
+            pod_name = "{}.{}".format(
                 item["metadata"]["name"],
                 item["metadata"]["namespace"],
             )
@@ -771,7 +772,7 @@ class K8sUsage:
                     continue
 
                 # Create unique pod key (same format as pods dictionary)
-                pod_key = "%s.%s" % (pod, namespace)
+                pod_key = f"{pod}.{namespace}"
 
                 # Get or create GpuMetrics instance for this pod
                 if pod_key not in self.gpuMetricsByPod:
@@ -808,7 +809,7 @@ class K8sUsage:
         if not self.gpuMetricsByPod:
             return
 
-        with open(str("%s/gpu_metrics.json" % KOA_CONFIG.frontend_data_location), "w") as fd:
+        with open(str(f"{KOA_CONFIG.frontend_data_location}/gpu_metrics.json"), "w") as fd:
             fd.write(json.dumps(self.gpuMetricsByPod, cls=JSONMarshaller))
 
     def consolidate_ns_usage(self):
@@ -899,7 +900,7 @@ class K8sUsage:
                 node.gpuUsage = round(node.gpuUsage / node.gpuCount, 2)
 
     def dump_nodes(self):
-        with open(str("%s/nodes.json" % KOA_CONFIG.frontend_data_location), "w") as fd:
+        with open(str(f"{KOA_CONFIG.frontend_data_location}/nodes.json"), "w") as fd:
             fd.write(json.dumps(self.nodes, cls=JSONMarshaller))
 
 
@@ -916,7 +917,7 @@ class Rrd:
     def __init__(self, db_files_location=None, dbname=None):
         create_directory_if_not_exists(db_files_location)
         self.dbname = dbname
-        self.rrd_location = str("%s/%s" % (KOA_CONFIG.db_location, dbname))
+        self.rrd_location = str(f"{KOA_CONFIG.db_location}/{dbname}")
         self.create_rrd_file_if_not_exists()
 
     def get_creation_time_epoch(self):
@@ -937,8 +938,8 @@ class Rrd:
                 str(KOA_CONFIG.polling_interval_sec),
                 "--start",
                 "0",
-                str("DS:cpu_usage:GAUGE:%d:U:U" % xfs),
-                str("DS:mem_usage:GAUGE:%d:U:U" % xfs),
+                f"DS:cpu_usage:GAUGE:{xfs}:U:U",
+                f"DS:mem_usage:GAUGE:{xfs}:U:U",
                 "RRA:AVERAGE:0.5:1:4032",
                 "RRA:AVERAGE:0.5:12:8880",
             )
@@ -946,14 +947,11 @@ class Rrd:
     def add_sample(self, timestamp_epoch, cpu_usage, mem_usage):
         KOA_LOGGER.debug("[puller][sample] %s, %f, %f", self.dbname, cpu_usage, mem_usage)
         try:
+            cpu_rounded = round(cpu_usage, KOA_CONFIG.db_round_decimals)
+            mem_rounded = round(mem_usage, KOA_CONFIG.db_round_decimals)
             rrdtool.update(
                 self.rrd_location,
-                "%s:%s:%s"
-                % (
-                    timestamp_epoch,
-                    round(cpu_usage, KOA_CONFIG.db_round_decimals),
-                    round(mem_usage, KOA_CONFIG.db_round_decimals),
-                ),
+                f"{timestamp_epoch}:{cpu_rounded}:{mem_rounded}",
             )
         except rrdtool.OperationalError:
             KOA_LOGGER.error("failing adding rrd sample => %s", traceback.format_exc())
@@ -987,10 +985,10 @@ class Rrd:
                     current_mem_usage = round(100 * float(cdp[1]), KOA_CONFIG.db_round_decimals) / 100
                     datetime_utc_json = time.strftime("%Y-%m-%dT%H:%M:%SZ", rrd_cdp_gmtime)
                     res_usage[ResUsageType.CPU].append(
-                        '{"name":"%s","dateUTC":"%s","usage":%f}' % (self.dbname, datetime_utc_json, current_cpu_usage)
+                        f'{{"name":"{self.dbname}","dateUTC":"{datetime_utc_json}","usage":{current_cpu_usage:f}}}'
                     )
                     res_usage[ResUsageType.MEMORY].append(
-                        '{"name":"%s","dateUTC":"%s","usage":%f}' % (self.dbname, datetime_utc_json, current_mem_usage)
+                        f'{{"name":"{self.dbname}","dateUTC":"{datetime_utc_json}","usage":{current_mem_usage:f}}}'
                     )
                     sum_res_usage[ResUsageType.CPU] += current_cpu_usage
                     sum_res_usage[ResUsageType.MEMORY] += current_mem_usage
@@ -1076,12 +1074,10 @@ class Rrd:
                     res_usage[res].append(current_trend_data[res])
 
         mem_label = "mem" if prefix else "memory"
-        with open(str("%s/%scpu_%s_trends.json" % (KOA_CONFIG.frontend_data_location, prefix, category)), "w") as fd:
+        with open(str(f"{KOA_CONFIG.frontend_data_location}/{prefix}cpu_{category}_trends.json"), "w") as fd:
             fd.write("[" + ",".join(res_usage[0]) + "]")
 
-        with open(
-            str("%s/%s%s_%s_trends.json" % (KOA_CONFIG.frontend_data_location, prefix, mem_label, category)), "w"
-        ) as fd:
+        with open(str(f"{KOA_CONFIG.frontend_data_location}/{prefix}{mem_label}_{category}_trends.json"), "w") as fd:
             fd.write("[" + ",".join(res_usage[1]) + "]")
 
     @staticmethod
@@ -1154,7 +1150,7 @@ class Rrd:
                                     KOA_CONFIG.db_round_decimals,
                                 )
 
-                        usage_export[res].append('{"stack":"%s","usage":%f,"date":"%s"}' % (db, usage_cost, date_key))
+                        usage_export[res].append(f'{{"stack":"{db}","usage":{usage_cost:f},"date":"{date_key}"}}')
                         if Rrd.get_date_group(now_gmtime, period) == date_key:
                             PROMETHEUS_PERIODIC_USAGE_EXPORTERS[period].labels(db, ResUsageType(res).name).set(
                                 usage_cost
@@ -1172,79 +1168,41 @@ class Rrd:
                                     KOA_CONFIG.db_round_decimals,
                                 )
 
-                        requests_export[res].append('{"stack":"%s","usage":%f,"date":"%s"}' % (db, req_cost, date_key))
+                        requests_export[res].append(f'{{"stack":"{db}","usage":{req_cost:f},"date":"{date_key}"}}')
                         if Rrd.get_date_group(now_gmtime, period) == date_key:
                             PROMETHEUS_PERIODIC_REQUESTS_EXPORTERS[period].labels(db, ResUsageType(res).name).set(
                                 req_cost
                             )  # noqa: E501
 
         mem_label = "mem" if prefix else "memory"
-        with open(
-            str(
-                "%s/%scpu_usage_period_%d.json"
-                % (
-                    KOA_CONFIG.frontend_data_location,
-                    prefix,
-                    period,
-                )
-            ),
-            "w",
-        ) as fd:
+        data_dir = KOA_CONFIG.frontend_data_location
+        with open(f"{data_dir}/{prefix}cpu_usage_period_{period}.json", "w") as fd:
             fd.write("[" + ",".join(usage_export[0]) + "]")
-        with open(
-            str(
-                "%s/%s%s_usage_period_%d.json"
-                % (
-                    KOA_CONFIG.frontend_data_location,
-                    prefix,
-                    mem_label,
-                    period,
-                )
-            ),
-            "w",
-        ) as fd:
+        with open(f"{data_dir}/{prefix}{mem_label}_usage_period_{period}.json", "w") as fd:
             fd.write("[" + ",".join(usage_export[1]) + "]")
-        with open(
-            str(
-                "%s/%scpu_requests_period_%d.json"
-                % (
-                    KOA_CONFIG.frontend_data_location,
-                    prefix,
-                    period,
-                )
-            ),
-            "w",
-        ) as fd:
+        with open(f"{data_dir}/{prefix}cpu_requests_period_{period}.json", "w") as fd:
             fd.write("[" + ",".join(requests_export[0]) + "]")
-        with open(
-            str(
-                "%s/%s%s_requests_period_%d.json" % (KOA_CONFIG.frontend_data_location, prefix, mem_label, period),
-            ),
-            "w",
-        ) as fd:
+        with open(f"{data_dir}/{prefix}{mem_label}_requests_period_{period}.json", "w") as fd:
             fd.write("[" + ",".join(requests_export[1]) + "]")
 
 
 def pull_k8s(api_context):
     data = None
-    api_endpoint = "%s%s" % (KOA_CONFIG.k8s_api_endpoint, api_context)
+    api_endpoint = f"{KOA_CONFIG.k8s_api_endpoint}{api_context}"
     headers = {}
     client_cert = None
     endpoint_info = urllib.parse.urlparse(KOA_CONFIG.k8s_api_endpoint)
     if KOA_CONFIG.enable_debug or (endpoint_info.hostname != "127.0.0.1" and endpoint_info.hostname != "localhost"):
         if KOA_CONFIG.k8s_auth_token != "NO_ENV_AUTH_TOKEN":
-            headers["Authorization"] = "%s %s" % (
-                KOA_CONFIG.k8s_auth_token_type,
-                KOA_CONFIG.k8s_auth_token,
-            )
+            headers["Authorization"] = f"{KOA_CONFIG.k8s_auth_token_type} {KOA_CONFIG.k8s_auth_token}"
         elif KOA_CONFIG.k8s_rbac_auth_token != "NO_ENV_TOKEN_FILE":
-            headers["Authorization"] = "Bearer %s" % KOA_CONFIG.k8s_rbac_auth_token
+            headers["Authorization"] = f"Bearer {KOA_CONFIG.k8s_rbac_auth_token}"
         elif (
             KOA_CONFIG.k8s_auth_username != "NO_ENV_AUTH_USERNAME"
             and KOA_CONFIG.k8s_auth_password != "NO_ENV_AUTH_PASSWORD"
         ):
-            token = base64.b64encode("%s:%s" % (KOA_CONFIG.k8s_auth_username, KOA_CONFIG.k8s_auth_password))
-            headers["Authorization"] = "Basic %s" % token
+            token = base64.b64encode(f"{KOA_CONFIG.k8s_auth_username}:{KOA_CONFIG.k8s_auth_password}")
+            headers["Authorization"] = f"Basic {token}"
         elif os.path.isfile(KOA_CONFIG.k8s_ssl_client_cert) and os.path.isfile(KOA_CONFIG.k8s_ssl_client_cert_key):
             client_cert = (KOA_CONFIG.k8s_ssl_client_cert, KOA_CONFIG.k8s_ssl_client_cert_key)
 
@@ -1468,7 +1426,7 @@ def dump_analytics(cost_model_by_user=None):
     try:
         export_interval = round(1.5 * KOA_CONFIG.polling_interval_sec)
         while True:
-            dbfiles: List[Any] = []
+            dbfiles: list[Any] = []
             for _, _, filenames in os.walk(KOA_CONFIG.db_location):
                 dbfiles.extend(filenames)
                 break
@@ -1535,7 +1493,7 @@ if __name__ == "__main__":
         "-v",
         "--version",
         action="version",
-        version="%(prog)s {}".format(KOA_CONFIG.version),
+        version=f"%(prog)s {KOA_CONFIG.version}",
     )
     args = parser.parse_args()
     th_puller = threading.Thread(target=create_metrics_puller)
@@ -1544,6 +1502,6 @@ if __name__ == "__main__":
     th_exporter.start()
 
     if not KOA_CONFIG.enable_debug:
-        waitress_serve(wsgi_dispatcher, listen="0.0.0.0:{}".format(KOA_CONFIG.listener_port))
+        waitress_serve(wsgi_dispatcher, listen=f"0.0.0.0:{KOA_CONFIG.listener_port}")
     else:
         app.run(host="0.0.0.0", port=KOA_CONFIG.listener_port)

--- a/manifests/kubeledger/helm/Chart.yaml
+++ b/manifests/kubeledger/helm/Chart.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
-appVersion: "26.01.1"
+appVersion: "26.05.0-b1"
 description: Helm chart for KubeLedger
 name: kubeledger
-version: 26.01.1
-
+version: 26.05.0-b1

--- a/manifests/kubeledger/helm/templates/deployment.yaml
+++ b/manifests/kubeledger/helm/templates/deployment.yaml
@@ -82,6 +82,42 @@ spec:
               name: data-vol
             - mountPath: /koa/static/data/
               name: static-data-vol
+        {{- if .Values.mcp.enabled }}
+        - name: mcp
+          image: "{{ .Values.image.repository }}:{{ include "kubeledger.imageVersion" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python3", "-u", "./mcp_server.py"]
+          env:
+            # The MCP server reads JSON files written by the backend container.
+            # Default ./static/data resolves to /koa/static/data (image WORKDIR),
+            # which matches the shared static-data-vol mount path below.
+            - name: KL_MCP_DATA_DIR
+              value: /koa/static/data
+          ports:
+            - name: mcp
+              containerPort: {{ .Values.mcp.service.targetPort }}
+              protocol: TCP
+          # TCP socket probes — protocol-agnostic baseline. HTTP/SSE endpoints
+          # may evolve; a TCP probe simply asserts the asyncio server is bound.
+          livenessProbe:
+            tcpSocket:
+              port: mcp
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: mcp
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.mcp.resources | nindent 12 }}
+          volumeMounts:
+            # Strictly read-only: the MCP server must not be able to mutate
+            # the data dumped by backend.py. See spec §3.1/§3.2.
+            - mountPath: /koa/static/data/
+              name: static-data-vol
+              readOnly: true
+        {{- end }}
       volumes:
       - name: static-data-vol
         emptyDir: {}

--- a/manifests/kubeledger/helm/templates/networkpolicy.yaml
+++ b/manifests/kubeledger/helm/templates/networkpolicy.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.networkPolicy.enabled }}
+# Network access control for the KubeLedger pod.
+#
+# Rationale (see docs/kubeledger-mcp-spec.md §3.5): the MCP server in v1 has
+# no authentication; this NetworkPolicy is the only access-control mechanism.
+# It therefore covers BOTH the backend (UI/API) and the MCP ports — leaving
+# either one unrestricted would defeat the purpose. Empty source lists mean
+# deny-by-default: a safe failure mode that requires explicit configuration.
+#
+# Prerequisite: the cluster's network plugin must enforce NetworkPolicy
+# (OVN-Kubernetes does, natively, on OpenShift).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "kubeledger.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubeledger.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kubeledger.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Backend (UI + Flask API + /metrics)
+    - from:
+        {{- toYaml .Values.networkPolicy.allowedSources | nindent 8 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.targetPort }}
+    {{- if .Values.mcp.enabled }}
+    # MCP server — only when mcp.enabled is true.
+    - from:
+        {{- toYaml .Values.networkPolicy.mcpAllowedSources | nindent 8 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.mcp.service.targetPort }}
+    {{- end }}
+{{- end }}

--- a/manifests/kubeledger/helm/templates/service.yaml
+++ b/manifests/kubeledger/helm/templates/service.yaml
@@ -12,6 +12,12 @@ spec:
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
+    {{- if .Values.mcp.enabled }}
+    - port: {{ .Values.mcp.service.port }}
+      targetPort: {{ .Values.mcp.service.targetPort }}
+      protocol: TCP
+      name: mcp
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "kubeledger.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/manifests/kubeledger/helm/values.yaml
+++ b/manifests/kubeledger/helm/values.yaml
@@ -59,6 +59,74 @@ service:
   port: 80
   targetPort: 5483
 
+# Optional MCP (Model Context Protocol) server.
+# When enabled, a second container is added to the pod, reusing the same image
+# with command override "python3 -u ./mcp_server.py". It reads static/data/*.json
+# in read-only mode and exposes the data to MCP clients (e.g. Claude Desktop)
+# via HTTP/SSE. Disabled by default — opt-in. See docs/kubeledger-mcp-spec.md.
+mcp:
+  enabled: false
+  # Port at which the MCP server listens inside the container, and the port
+  # exposed by the Service. Defaults to 5484 — one above the backend's 5483,
+  # to keep the two KubeLedger ports adjacent and memorable.
+  # Keep both aligned with the MCP server bind port.
+  service:
+    port: 5484
+    targetPort: 5484
+  # Per-container resource block for the MCP sidecar. The MCP server is light
+  # (JSON parsing + asyncio); the defaults reflect that.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    # limits:
+    #   cpu: 200m
+    #   memory: 256Mi
+
+# NetworkPolicy for the KubeLedger pod.
+# In v1 the MCP server has no authentication; access control relies entirely
+# on this NetworkPolicy. It is therefore enabled by default and covers BOTH
+# the backend (HTTP/UI) and the MCP ports. Empty source lists mean
+# deny-by-default: an operator must explicitly list authorized clients.
+# Requires a network plugin that enforces NetworkPolicy (e.g. OVN-Kubernetes
+# on OpenShift).
+networkPolicy:
+  enabled: true
+  # NetworkPolicyPeer entries (namespaceSelector / podSelector / ipBlock)
+  # authorized to reach the backend (UI + Flask API + /metrics). Empty list
+  # = deny-by-default. Examples (uncomment and adapt as needed):
+  #
+  # allowedSources:
+  #   # Pods opted-in via label inside the same namespace
+  #   - podSelector:
+  #       matchLabels:
+  #         kubeledger-client: "true"
+  #   # Any pod from a labelled namespace
+  #   - namespaceSelector:
+  #       matchLabels:
+  #         kubernetes.io/metadata.name: monitoring
+  #   # Specific Prometheus pods scraping /metrics
+  #   - namespaceSelector:
+  #       matchLabels:
+  #         kubernetes.io/metadata.name: openshift-monitoring
+  #     podSelector:
+  #       matchLabels:
+  #         app.kubernetes.io/name: prometheus
+  #   # A trusted CIDR (e.g. corporate ingress)
+  #   - ipBlock:
+  #       cidr: 10.0.0.0/16
+  allowedSources: []
+  # NetworkPolicyPeer entries authorized to reach the MCP server.
+  # Typically a stricter set than allowedSources. Same shape as above.
+  # Empty list = no source authorized — MCP unreachable, even when
+  # mcp.enabled is true. Example: only allow the AI assistant proxy pod.
+  #
+  # mcpAllowedSources:
+  #   - podSelector:
+  #       matchLabels:
+  #         app.kubernetes.io/name: claude-mcp-proxy
+  mcpAllowedSources: []
+
 ingress:
   enabled: false
   annotations: {}

--- a/manifests/kubeledger/kustomize/kustomization.yaml
+++ b/manifests/kubeledger/kustomize/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: kubeledger
     newName: ghcr.io/realopslabs/kubeledger
-    newTag: 26.01.1
+    newTag: 26.05.0-b1

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1997,12 +1997,19 @@ def _build_mcp_app() -> Any:
     keeps the unit tests (which never call main()) light.
     """
     from mcp.server.fastmcp import FastMCP
+    from mcp.types import ToolAnnotations
 
     host = _get_env("MCP_LISTEN_HOST", "0.0.0.0") or "0.0.0.0"
     try:
         port = int(_get_env("MCP_LISTEN_PORT", "5484") or "5484")
     except (TypeError, ValueError):
         port = 5484
+
+    read_only_tool_annotations = ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        openWorldHint=False,
+    )
 
     app = FastMCP(
         name="kubeledger-mcp",
@@ -2030,17 +2037,17 @@ def _build_mcp_app() -> Any:
     #   - Return ``Dict[str, Any]`` — FastMCP serialises and (when the SDK
     #     supports it) puts the result under ``structuredContent``.
 
-    @app.tool()
+    @app.tool(annotations=read_only_tool_annotations)
     def list_namespaces() -> dict[str, Any]:
         """List available namespaces (application / system) and the known special entries."""
         return tool_list_namespaces()
 
-    @app.tool()
+    @app.tool(annotations=read_only_tool_annotations)
     def describe_dataset() -> dict[str, Any]:
         """Announce dataset capabilities: metrics, GPU availability, scales, efficiency, cost_model."""
         return tool_describe_dataset()
 
-    @app.tool()
+    @app.tool(annotations=read_only_tool_annotations)
     def get_usage(
         metric: Literal["cpu", "memory"],
         scale: Literal["daily_14d", "monthly_12m"],
@@ -2055,7 +2062,7 @@ def _build_mcp_app() -> Any:
             exclude_special=exclude_special,
         )
 
-    @app.tool()
+    @app.tool(annotations=read_only_tool_annotations)
     def get_top_consumers(
         metric: Literal["cpu", "memory"],
         scale: Literal["daily_14d", "monthly_12m"],
@@ -2072,7 +2079,7 @@ def _build_mcp_app() -> Any:
             date=date,
         )
 
-    @app.tool()
+    @app.tool(annotations=read_only_tool_annotations)
     def get_namespace_breakdown(
         metric: Literal["cpu", "memory"],
         scale: Literal["daily_14d", "monthly_12m"],
@@ -2087,7 +2094,7 @@ def _build_mcp_app() -> Any:
             exclude_system=exclude_system,
         )
 
-    @app.tool()
+    @app.tool(annotations=read_only_tool_annotations)
     def get_efficiency(
         scale: Literal["daily_14d", "monthly_12m"],
         namespace: str | None = None,
@@ -2096,7 +2103,7 @@ def _build_mcp_app() -> Any:
         """Return usage/requests ratio per (namespace, metric) — descriptive classification."""
         return tool_get_efficiency(scale=scale, namespace=namespace, metric=metric)
 
-    @app.tool()
+    @app.tool(annotations=read_only_tool_annotations)
     def get_timeseries(
         metric: Literal["cpu", "memory"],
         namespace: str,
@@ -2104,7 +2111,7 @@ def _build_mcp_app() -> Any:
         """Hourly usage series over the trends window for a single namespace, with min/max/mean."""
         return tool_get_timeseries(metric=metric, namespace=namespace)
 
-    @app.tool()
+    @app.tool(annotations=read_only_tool_annotations)
     def compare_periods(
         metric: Literal["cpu", "memory"],
         namespace: str,
@@ -2112,7 +2119,7 @@ def _build_mcp_app() -> Any:
         """Compare 14-day aggregate against monthly trajectory; descriptive trend direction."""
         return tool_compare_periods(metric=metric, namespace=namespace)
 
-    @app.tool()
+    @app.tool(annotations=read_only_tool_annotations)
     def get_efficiency_timeseries(
         metric: Literal["cpu", "memory"],
         namespace: str,
@@ -2120,7 +2127,7 @@ def _build_mcp_app() -> Any:
         """Hourly efficiency factor (rf = usage/requests) series — not bounded at 1."""
         return tool_get_efficiency_timeseries(metric=metric, namespace=namespace)
 
-    @app.tool()
+    @app.tool(annotations=read_only_tool_annotations)
     def group_namespaces(
         metric: Literal["cpu", "memory"],
         scale: Literal["daily_14d", "monthly_12m"],

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,2260 @@
+#!/usr/bin/env python
+"""KubeLedger MCP server.
+
+Read-only MCP (Model Context Protocol) server exposing KubeLedger analytics
+that backend.py already materializes as JSON files under static/data/. The
+server never reads the RRD databases directly, never writes, and never embeds
+an LLM — it is a descriptive data surface, and the narrative intelligence is
+brought by the MCP client.
+
+This file is built up incrementally, following the implementation plan of
+docs/kubeledger-mcp-spec.md (section 7.2). The current revision covers
+step 1: the data access layer.
+"""
+
+__author__ = "Rodrigue Chakode"
+__copyright__ = "Copyright 2026 Rodrigue Chakode and contributors"
+__license__ = "Business Source License 1.1"
+
+import collections
+import fnmatch
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_DATA_DIR = "./static/data"
+BACKEND_CONFIG_FILENAME = "backend.json"
+
+# Histogram periods written by backend.py:dump_histogram_analytics.
+# These are not granularities — they are retrieval windows. backend.py groups
+# by month for the year window and by day for the 14-day window. See spec §2.1.
+PERIOD_14_DAYS_SEC = 1209600
+PERIOD_YEAR_SEC = 31968000
+
+# Public scale identifiers exposed by the MCP tools.
+SCALE_DAILY_14D = "daily_14d"
+SCALE_MONTHLY_12M = "monthly_12m"
+SCALE_TO_PERIOD = {
+    SCALE_DAILY_14D: PERIOD_14_DAYS_SEC,
+    SCALE_MONTHLY_12M: PERIOD_YEAR_SEC,
+}
+SCALE_GRANULARITY = {
+    SCALE_DAILY_14D: "daily",
+    SCALE_MONTHLY_12M: "monthly",
+}
+SCALE_DEFAULT_DEPTH = {
+    SCALE_DAILY_14D: "14 days",
+    SCALE_MONTHLY_12M: "~12 months",
+}
+
+# Translation from the cost_model written by backend.py to its semantic unit
+# (used in the metadata block of every MCP response — spec §4.6).
+COST_MODEL_UNIT = {
+    "cumulative": "percent_of_cluster_capacity",
+    "normalized": "relative_share_percent",
+    "costs": "monetary_cost",
+}
+
+METRICS = ("cpu", "memory")
+DIMENSIONS = ("usage", "requests")
+
+# Prefixes used to classify namespaces as "system" rather than "application"
+# (spec §4.1, §2.4). OpenShift is the primary context (operators in
+# openshift-*); the standard upstream Kubernetes namespaces (kube-system,
+# kube-public, kube-node-lease) share the same role.
+SYSTEM_NAMESPACE_PREFIXES = ("openshift-", "kube-")
+
+# Special entries that are NOT namespaces — see spec §2.4. Always listed
+# in list_namespaces' special_entries block, regardless of whether they
+# happen to appear in the data on this particular run.
+SPECIAL_ENTRIES: dict[str, dict[str, str]] = {
+    "non-allocatable": {
+        "role": "cluster_overhead",
+        "description": (
+            "Cluster capacity reserved for system overhead, not allocatable "
+            "to pods. Excluded from usage analyses by default, but exposed as "
+            "a separate signal — e.g. cluster_overhead in get_namespace_breakdown."
+        ),
+    },
+    ".billing-hourly-rate": {
+        "role": "billing_config",
+        "description": (
+            "Hourly billing rate, present only when cost_model=costs. Not a usage data point — a configuration value."
+        ),
+    },
+}
+
+# Warn when the most recent data file is older than this many seconds.
+# backend.py dumps every ~5 minutes; 30 minutes leaves ample headroom.
+FRESHNESS_WARN_AFTER_SECONDS = 1800
+
+# Efficiency / requests handling (spec §4.3).
+#
+# requests is derived in backend.py as ``usage / rf`` (request factor), so a
+# very high rf yields an *infinitesimal* but non-zero requests value. The
+# exact ``requests == 0`` test is therefore insufficient — any value below
+# this threshold must be treated as zero, otherwise usage/requests produces
+# numerical aberrations.
+REQUESTS_ZERO_THRESHOLD = 1e-6
+
+# Efficiency classification thresholds (descriptive, not prescriptive).
+# - ratio < 0.5  → over_provisioned (usage much smaller than requests)
+# - 0.5 ≤ ratio ≤ 1.0 → balanced
+# - ratio > 1.0  → under_provisioned (usage exceeds requests)
+EFFICIENCY_OVER_PROVISIONED_BELOW = 0.5
+EFFICIENCY_UNDER_PROVISIONED_ABOVE = 1.0
+
+# Relative change threshold for ``compare_periods`` trend classification —
+# noise filter, applied to the difference between first-half and second-half
+# means of the monthly series. 10 % of the baseline.
+TREND_CHANGE_THRESHOLD = 0.10
+
+# Maximum length of a glob pattern accepted by ``tool_group_namespaces``.
+# fnmatch internally compiles to a regex; pathological patterns built from
+# many wildcards (e.g. ``"*?" * 1000``) can cause catastrophic backtracking.
+# 256 chars is far above any realistic namespace selector and below the
+# point where regex compilation cost matters.
+GROUP_PATTERN_MAX_LENGTH = 256
+
+
+def _get_env(name: str, default: str | None = None) -> str | None:
+    """Read an environment variable, KL_<name> taking precedence over KOA_<name>.
+
+    Mirrors backend.py:get_backend_config_env so operators configure the MCP
+    container with the same convention as the main backend.
+    """
+    kl_value = os.environ.get(f"KL_{name}")
+    if kl_value is not None:
+        return kl_value
+    return os.environ.get(f"KOA_{name}", default)
+
+
+def get_data_dir() -> Path:
+    """Resolve the directory holding KubeLedger static data files."""
+    value = _get_env("MCP_DATA_DIR", DEFAULT_DATA_DIR)
+    return Path(value or DEFAULT_DATA_DIR)
+
+
+# ---------------------------------------------------------------------------
+# Robust JSON reader
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FileReadResult:
+    """Outcome of a JSON file read attempt.
+
+    The reader never raises: every failure mode is reported through this
+    structure, so callers can decide whether the failure is recoverable
+    (missing accessory file → warning) or fatal for the request (missing
+    file required to answer → MCP error).
+    """
+
+    filename: str
+    path: Path
+    exists: bool
+    payload: Any
+    error: str | None
+    mtime_utc: float | None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None and self.payload is not None
+
+
+def read_json_file(filename: str, data_dir: Path | None = None) -> FileReadResult:
+    """Read and parse a JSON file from the data directory, never raising.
+
+    Failure modes intercepted:
+
+    - **Missing file** → ``exists=False``, ``payload=None``, ``error`` set.
+    - **OS-level read failure** → ``exists=True``, ``payload=None``, ``error`` set.
+    - **Malformed or truncated JSON** → ``exists=True``, ``payload=None``,
+      ``error`` set. backend.py writes histogram and trend files by string
+      concatenation (``"[" + ",".join(parts) + "]"``); a crash mid-write
+      leaves a syntactically invalid file. ``json.JSONDecodeError`` must
+      therefore be caught here and must never propagate up to the MCP
+      transport, where it would terminate the client connection.
+
+    On success the parsed JSON is returned in ``payload``. For the files
+    produced by backend.py this is typically a ``list[dict]`` (histograms,
+    trends) or a ``dict`` (``backend.json``).
+
+    Path containment: today every call site uses a fixed name derived from
+    :func:`histogram_filename`, :func:`trends_filename`, or
+    :data:`BACKEND_CONFIG_FILENAME`, so traversal cannot happen. The guard
+    below makes that contract explicit — any future caller passing
+    untrusted input will fail closed rather than escape the data directory.
+    """
+    if "/" in filename or "\\" in filename or ".." in filename or filename.startswith("."):
+        # Defensive guard. ``.billing-hourly-rate`` and similar dot-prefixed
+        # names are valid namespace entries but never used as filenames here.
+        return FileReadResult(
+            filename=filename,
+            path=Path(filename),
+            exists=False,
+            payload=None,
+            error=f"invalid filename {filename!r}: path traversal characters not allowed",
+            mtime_utc=None,
+        )
+
+    root = data_dir if data_dir is not None else get_data_dir()
+    path = root / filename
+
+    if not path.is_file():
+        return FileReadResult(
+            filename=filename,
+            path=path,
+            exists=False,
+            payload=None,
+            error=f"file not found: {path}",
+            mtime_utc=None,
+        )
+
+    try:
+        mtime = path.stat().st_mtime
+    except OSError as exc:
+        return FileReadResult(
+            filename=filename,
+            path=path,
+            exists=True,
+            payload=None,
+            error=f"stat failed: {exc}",
+            mtime_utc=None,
+        )
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return FileReadResult(
+            filename=filename,
+            path=path,
+            exists=True,
+            payload=None,
+            error=f"read failed: {exc}",
+            mtime_utc=mtime,
+        )
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return FileReadResult(
+            filename=filename,
+            path=path,
+            exists=True,
+            payload=None,
+            error=f"invalid JSON: {exc.msg} (line {exc.lineno}, column {exc.colno})",
+            mtime_utc=mtime,
+        )
+
+    return FileReadResult(
+        filename=filename,
+        path=path,
+        exists=True,
+        payload=payload,
+        error=None,
+        mtime_utc=mtime,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Filename helpers — derived from backend.py:dump_histogram_analytics and
+# dump_trend_analytics. The MCP holds no other assumption about file paths.
+# ---------------------------------------------------------------------------
+
+
+def _mem_label(gpu: bool) -> str:
+    # backend.py uses "memory" for standard metrics and "mem" when the
+    # gpu_ prefix is applied — see backend.py:1078 and 1181.
+    return "mem" if gpu else "memory"
+
+
+def histogram_filename(metric: str, dimension: str, period_sec: int, gpu: bool = False) -> str:
+    """Return the filename produced by backend.py for a given histogram.
+
+    Args:
+        metric: ``"cpu"`` or ``"memory"``.
+        dimension: ``"usage"`` or ``"requests"``.
+        period_sec: ``PERIOD_14_DAYS_SEC`` or ``PERIOD_YEAR_SEC``.
+        gpu: ``True`` to select the GPU variant (``gpu_*`` prefix).
+
+    """
+    if metric not in METRICS:
+        raise ValueError(f"unknown metric: {metric!r} (expected one of {METRICS})")
+    if dimension not in DIMENSIONS:
+        raise ValueError(f"unknown dimension: {dimension!r} (expected one of {DIMENSIONS})")
+    prefix = "gpu_" if gpu else ""
+    res = "cpu" if metric == "cpu" else _mem_label(gpu)
+    return f"{prefix}{res}_{dimension}_period_{period_sec}.json"
+
+
+def trends_filename(metric: str, category: str, gpu: bool = False) -> str:
+    """Return the filename produced by backend.py for a given trends series.
+
+    Args:
+        metric: ``"cpu"`` or ``"memory"``.
+        category: ``"usage"`` or ``"rf"`` (request factor). ``rf`` only
+            exists in the non-GPU variant — backend.py does not emit
+            ``gpu_*_rf_trends.json``.
+        gpu: ``True`` to select the GPU variant.
+
+    """
+    if metric not in METRICS:
+        raise ValueError(f"unknown metric: {metric!r} (expected one of {METRICS})")
+    if category not in ("usage", "rf"):
+        raise ValueError(f"unknown category: {category!r} (expected 'usage' or 'rf')")
+    prefix = "gpu_" if gpu else ""
+    res = "cpu" if metric == "cpu" else _mem_label(gpu)
+    return f"{prefix}{res}_{category}_trends.json"
+
+
+# ---------------------------------------------------------------------------
+# Cost model — loaded from static/data/backend.json (spec §2.3)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CostModelInfo:
+    """Cost model in effect, as written by backend.py at start-up.
+
+    The labels here are the **translated** ones from ``backend.json``
+    (``cumulative`` / ``normalized`` / ``costs``), not the internal config
+    names (``CUMULATIVE_RATIO`` / ``RATIO`` / ``CHARGE_BACK``). The MCP must
+    only consider the translated labels — see spec §2.3.
+    """
+
+    cost_model: str
+    currency: str
+    unit: str  # Semantic unit derived from cost_model (spec §4.6 mapping).
+
+
+def load_cost_model(data_dir: Path | None = None) -> tuple[CostModelInfo | None, list[str]]:
+    """Load the cost model from ``backend.json``.
+
+    Returns:
+        ``(info, warnings)``. ``info`` is ``None`` when the file is missing
+        or unusable; ``warnings`` collects every recoverable issue so the
+        caller can surface them in the MCP response.
+
+    """
+    warnings: list[str] = []
+    result = read_json_file(BACKEND_CONFIG_FILENAME, data_dir=data_dir)
+    if not result.ok:
+        warnings.append(f"backend.json unreadable: {result.error}")
+        return None, warnings
+
+    payload = result.payload
+    if not isinstance(payload, dict):
+        warnings.append(f"backend.json: expected a JSON object, got {type(payload).__name__}")
+        return None, warnings
+
+    cost_model = payload.get("cost_model")
+    currency = payload.get("currency")
+    if not isinstance(cost_model, str) or not isinstance(currency, str):
+        warnings.append("backend.json: missing or non-string cost_model/currency")
+        return None, warnings
+
+    unit = COST_MODEL_UNIT.get(cost_model)
+    if unit is None:
+        warnings.append(f"backend.json: unknown cost_model {cost_model!r}")
+        unit = "unknown"
+
+    return CostModelInfo(cost_model=cost_model, currency=currency, unit=unit), warnings
+
+
+# ---------------------------------------------------------------------------
+# Dataset discovery — describe what the data directory currently exposes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScaleInfo:
+    granularity: str
+    depth: str
+    points_per_namespace: int
+
+
+@dataclass(frozen=True)
+class TrendsInfo:
+    granularity: str
+    depth: str
+    points_per_namespace: int
+
+
+@dataclass(frozen=True)
+class EfficiencyInfo:
+    aggregated: bool
+    hourly_timeseries: bool
+
+
+@dataclass(frozen=True)
+class DatasetInfo:
+    """Snapshot of the dataset currently exposed by ``static/data/``.
+
+    Built from the **files that actually exist** at probe time. Depths and
+    point counts are derived from the data — never hard-coded — so that the
+    response stays honest if backend.py runs in a degraded mode (spec §7.2
+    point 1, "honnêteté temporelle").
+    """
+
+    metrics_available: list[str]
+    gpu_available: bool
+    scales: dict[str, ScaleInfo]
+    trends: TrendsInfo | None
+    dimensions: list[str]
+    efficiency: EfficiencyInfo
+    cost_model: CostModelInfo | None
+    billing_hourly_rate: float | None
+    data_freshness_utc: str | None
+    warnings: list[str] = field(default_factory=list)
+
+
+def _unique_count(payload: Any, key: str) -> int:
+    """Return the number of distinct values of ``key`` in a list payload."""
+    if not isinstance(payload, list):
+        return 0
+    return len({entry[key] for entry in payload if isinstance(entry, dict) and key in entry})
+
+
+def _iso_utc(epoch_seconds: float) -> str:
+    """Format a POSIX timestamp as an ISO 8601 UTC string (no microseconds)."""
+    return datetime.fromtimestamp(epoch_seconds, tz=UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _trends_depth(payload: Any) -> tuple[str | None, int]:
+    """Derive (human-readable depth, points_per_namespace) from a trends payload.
+
+    backend.py:dump_trend_data writes one entry per (namespace, hour) — so
+    for any single namespace, ``points_per_namespace`` equals the number of
+    distinct ``dateUTC`` timestamps. We use distinct timestamps over the whole
+    file as an upper bound, which is what describe_dataset wants to expose.
+    """
+    if not isinstance(payload, list):
+        return None, 0
+    timestamps = sorted(
+        {entry["dateUTC"] for entry in payload if isinstance(entry, dict) and isinstance(entry.get("dateUTC"), str)}
+    )
+    if not timestamps:
+        return None, 0
+    points = len(timestamps)
+    if len(timestamps) < 2:
+        return "1 hour", points
+    try:
+        first = datetime.fromisoformat(timestamps[0].replace("Z", "+00:00"))
+        last = datetime.fromisoformat(timestamps[-1].replace("Z", "+00:00"))
+    except ValueError:
+        return None, points
+    span_hours = (last - first).total_seconds() / 3600.0
+    span_days = span_hours / 24.0
+    if span_days >= 1.5:
+        return f"{round(span_days):.0f} days", points
+    return f"{round(span_hours):.0f} hours", points
+
+
+def discover_dataset(data_dir: Path | None = None) -> DatasetInfo:
+    """Probe ``static/data/`` and describe what is currently available.
+
+    Never raises. Anything that prevents the discovery from completing
+    cleanly is recorded as a warning in the returned :class:`DatasetInfo`.
+    """
+    root = data_dir if data_dir is not None else get_data_dir()
+    warnings: list[str] = []
+
+    cost_model, cm_warnings = load_cost_model(data_dir=root)
+    warnings.extend(cm_warnings)
+
+    # ------------------------------------------------------------------
+    # Probe histograms — which (metric, dimension, scale, gpu) files exist.
+    # ------------------------------------------------------------------
+
+    probed: dict[str, FileReadResult] = {}
+
+    def _probe(filename: str) -> FileReadResult:
+        if filename not in probed:
+            probed[filename] = read_json_file(filename, data_dir=root)
+        return probed[filename]
+
+    metrics_available: list[str] = []
+    for metric in METRICS:
+        for scale in (SCALE_DAILY_14D, SCALE_MONTHLY_12M):
+            fname = histogram_filename(metric, "usage", SCALE_TO_PERIOD[scale])
+            if _probe(fname).exists:
+                if metric not in metrics_available:
+                    metrics_available.append(metric)
+                break
+
+    gpu_available = False
+    for metric in METRICS:
+        for scale in (SCALE_DAILY_14D, SCALE_MONTHLY_12M):
+            fname = histogram_filename(metric, "usage", SCALE_TO_PERIOD[scale], gpu=True)
+            r = _probe(fname)
+            if r.ok and isinstance(r.payload, list) and r.payload:
+                gpu_available = True
+                break
+        if gpu_available:
+            break
+
+    dimensions: list[str] = []
+    if metrics_available:
+        if any(
+            _probe(histogram_filename(m, "usage", SCALE_TO_PERIOD[s])).exists
+            for m in metrics_available
+            for s in (SCALE_DAILY_14D, SCALE_MONTHLY_12M)
+        ):
+            dimensions.append("usage")
+        if any(
+            _probe(histogram_filename(m, "requests", SCALE_TO_PERIOD[s])).exists
+            for m in metrics_available
+            for s in (SCALE_DAILY_14D, SCALE_MONTHLY_12M)
+        ):
+            dimensions.append("requests")
+
+    # ------------------------------------------------------------------
+    # Scales — depth and points derived from data when readable.
+    # ------------------------------------------------------------------
+
+    scales: dict[str, ScaleInfo] = {}
+    for scale in (SCALE_DAILY_14D, SCALE_MONTHLY_12M):
+        sample = None
+        for metric in metrics_available or METRICS:
+            r = _probe(histogram_filename(metric, "usage", SCALE_TO_PERIOD[scale]))
+            if r.ok and isinstance(r.payload, list) and r.payload:
+                sample = r
+                break
+        if sample is None:
+            continue
+        points = _unique_count(sample.payload, "date")
+        scales[scale] = ScaleInfo(
+            granularity=SCALE_GRANULARITY[scale],
+            depth=SCALE_DEFAULT_DEPTH[scale],
+            points_per_namespace=points,
+        )
+
+    # ------------------------------------------------------------------
+    # Trends — depth derived from the first usage trends file we can read.
+    # ------------------------------------------------------------------
+
+    trends: TrendsInfo | None = None
+    for metric in metrics_available or METRICS:
+        r = _probe(trends_filename(metric, "usage"))
+        if r.ok and isinstance(r.payload, list) and r.payload:
+            depth, points = _trends_depth(r.payload)
+            trends = TrendsInfo(
+                granularity="hourly",
+                depth=depth or "unknown",
+                points_per_namespace=points,
+            )
+            break
+
+    # ------------------------------------------------------------------
+    # Efficiency capability — aggregated vs. hourly timeseries.
+    # ------------------------------------------------------------------
+
+    aggregated_efficiency = "requests" in dimensions
+    hourly_rf = any(_probe(trends_filename(m, "rf")).exists for m in metrics_available or METRICS)
+    efficiency = EfficiencyInfo(
+        aggregated=aggregated_efficiency,
+        hourly_timeseries=hourly_rf,
+    )
+
+    # ------------------------------------------------------------------
+    # Data freshness — most recent mtime across the data files probed.
+    # backend.json is excluded: it is written once at start-up and its
+    # mtime does not reflect data freshness (spec §7.2 point 5).
+    # ------------------------------------------------------------------
+
+    mtimes = [
+        r.mtime_utc for fname, r in probed.items() if r.mtime_utc is not None and fname != BACKEND_CONFIG_FILENAME
+    ]
+    data_freshness_utc = _iso_utc(max(mtimes)) if mtimes else None
+
+    # ------------------------------------------------------------------
+    # billing_hourly_rate — exposed only in cost_model=costs.
+    # backend.py does not write this value into backend.json today, and it
+    # filters the .billing-hourly-rate entry out of the histogram outputs
+    # (see backend.py:1144). The value is therefore not reachable from the
+    # static JSON surface in v1. We surface this gap as a warning rather
+    # than guessing — the caller knows the field is unavailable.
+    # ------------------------------------------------------------------
+
+    billing_hourly_rate: float | None = None
+    if cost_model is not None and cost_model.cost_model == "costs":
+        warnings.append(
+            "billing_hourly_rate is not exposed in the current static data set; "
+            "backend.json carries only cost_model and currency."
+        )
+
+    return DatasetInfo(
+        metrics_available=metrics_available,
+        gpu_available=gpu_available,
+        scales=scales,
+        trends=trends,
+        dimensions=dimensions,
+        efficiency=efficiency,
+        cost_model=cost_model,
+        billing_hourly_rate=billing_hourly_rate,
+        data_freshness_utc=data_freshness_utc,
+        warnings=warnings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Namespace classification & collection
+# ---------------------------------------------------------------------------
+
+
+def classify_namespace(name: str) -> str:
+    """Return the type of a namespace-like entry seen in the data.
+
+    Possible values:
+
+    - ``"special"`` if ``name`` is a known special entry (``non-allocatable``,
+      ``.billing-hourly-rate`` — see spec §2.4).
+    - ``"system"`` if ``name`` starts with a known system prefix
+      (``openshift-``, ``kube-``).
+    - ``"application"`` otherwise.
+    """
+    if name in SPECIAL_ENTRIES:
+        return "special"
+    for prefix in SYSTEM_NAMESPACE_PREFIXES:
+        if name.startswith(prefix):
+            return "system"
+    return "application"
+
+
+def _iter_data_filenames(include_gpu: bool = True) -> list[str]:
+    """Enumerate every data filename produced by backend.py:dump_analytics."""
+    out: list[str] = []
+    gpu_variants = (False, True) if include_gpu else (False,)
+    for metric in METRICS:
+        for period in (PERIOD_14_DAYS_SEC, PERIOD_YEAR_SEC):
+            for dimension in DIMENSIONS:
+                for gpu in gpu_variants:
+                    out.append(histogram_filename(metric, dimension, period, gpu=gpu))
+        for category in ("usage", "rf"):
+            for gpu in gpu_variants:
+                # backend.py emits no gpu_*_rf_trends.json — see spec §2.2.
+                if gpu and category == "rf":
+                    continue
+                out.append(trends_filename(metric, category, gpu=gpu))
+    return out
+
+
+def _collect_namespace_names(
+    data_dir: Path | None = None,
+) -> tuple[set, list[str], float | None]:
+    """Walk all data files, collect every entry name seen.
+
+    Returns:
+        ``(names, warnings, latest_mtime)`` where ``names`` is the union of
+        every ``stack`` (histograms) and ``name`` (trends) field observed,
+        ``warnings`` lists files that exist but failed to parse (recoverable),
+        and ``latest_mtime`` is the most recent POSIX mtime across files
+        actually read — used to compute ``generated_at_utc``.
+
+    """
+    root = data_dir if data_dir is not None else get_data_dir()
+    names: set = set()
+    warnings: list[str] = []
+    latest_mtime: float | None = None
+
+    for fname in _iter_data_filenames():
+        result = read_json_file(fname, data_dir=root)
+        if not result.exists:
+            continue
+        if result.mtime_utc is not None:
+            latest_mtime = result.mtime_utc if latest_mtime is None else max(latest_mtime, result.mtime_utc)
+        if not result.ok:
+            warnings.append(f"{fname}: {result.error}")
+            continue
+        if not isinstance(result.payload, list):
+            warnings.append(f"{fname}: expected a list at top level")
+            continue
+        for entry in result.payload:
+            if not isinstance(entry, dict):
+                continue
+            stack = entry.get("stack")
+            if isinstance(stack, str):
+                names.add(stack)
+            tname = entry.get("name")
+            if isinstance(tname, str):
+                names.add(tname)
+
+    return names, warnings, latest_mtime
+
+
+# ---------------------------------------------------------------------------
+# Common response metadata block (spec §4.6)
+# ---------------------------------------------------------------------------
+
+
+def build_metadata(
+    cost_model: CostModelInfo | None,
+    warnings: list[str] | None = None,
+    metric: str | None = None,
+    scale: str | None = None,
+    data_window: dict[str, Any] | None = None,
+    source_file: str | None = None,
+    generated_at_mtime: float | None = None,
+    unit_override: str | None = None,
+) -> dict[str, Any]:
+    """Build the metadata block returned with every tool response.
+
+    ``cost_model`` / ``currency`` / ``unit`` are global (derived from
+    ``backend.json``). The remaining fields are tool-specific and omitted
+    when not applicable. Always returns the same shape — unused fields are
+    set to ``null`` so the schema is predictable for clients.
+
+    A freshness warning is appended automatically when ``generated_at_mtime``
+    is older than :data:`FRESHNESS_WARN_AFTER_SECONDS`.
+    """
+    out_warnings = list(warnings) if warnings else []
+
+    if generated_at_mtime is not None:
+        generated_at_utc = _iso_utc(generated_at_mtime)
+        age_sec = datetime.now(tz=UTC).timestamp() - generated_at_mtime
+        if age_sec > FRESHNESS_WARN_AFTER_SECONDS:
+            out_warnings.append(f"stale data: most recent file is {age_sec / 60.0:.0f} minutes old")
+    else:
+        generated_at_utc = None
+
+    return {
+        "cost_model": cost_model.cost_model if cost_model else None,
+        "currency": cost_model.currency if cost_model else None,
+        "unit": unit_override or (cost_model.unit if cost_model else None),
+        "metric": metric,
+        "scale": scale,
+        "data_window": data_window,
+        "source_file": source_file,
+        "generated_at_utc": generated_at_utc,
+        "warnings": out_warnings,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tools — Discovery group (spec §4.1)
+# ---------------------------------------------------------------------------
+
+
+def tool_list_namespaces(data_dir: Path | None = None) -> dict[str, Any]:
+    """Implement the ``list_namespaces`` MCP tool.
+
+    Returns the real namespaces seen across all data files (classified as
+    ``application`` or ``system``) and the known special entries — listed
+    explicitly so the client cannot confuse them with namespaces.
+    """
+    root = data_dir if data_dir is not None else get_data_dir()
+    names, warnings, latest_mtime = _collect_namespace_names(data_dir=root)
+    cost_model, cm_warnings = load_cost_model(data_dir=root)
+    warnings.extend(cm_warnings)
+
+    namespaces: list[dict[str, str]] = []
+    counts = {"application": 0, "system": 0, "special": 0}
+    for name in sorted(names):
+        kind = classify_namespace(name)
+        if kind == "special":
+            # Special entries are surfaced in their own block, not mingled
+            # with the namespace list. We intentionally do NOT silently drop
+            # them — they are accounted for via SPECIAL_ENTRIES below.
+            continue
+        namespaces.append({"name": name, "type": kind})
+        counts[kind] += 1
+
+    special_entries: list[dict[str, str]] = []
+    for entry_name, meta in SPECIAL_ENTRIES.items():
+        special_entries.append(
+            {
+                "name": entry_name,
+                "role": meta["role"],
+                "description": meta["description"],
+            }
+        )
+    counts["special"] = len(special_entries)
+
+    return {
+        "namespaces": namespaces,
+        "special_entries": special_entries,
+        "counts": counts,
+        "metadata": build_metadata(
+            cost_model=cost_model,
+            warnings=warnings,
+            generated_at_mtime=latest_mtime,
+        ),
+    }
+
+
+def tool_describe_dataset(data_dir: Path | None = None) -> dict[str, Any]:
+    """Implement the ``describe_dataset`` MCP tool.
+
+    Announces what the dataset currently exposes — metrics, GPU availability,
+    scales (with actual point counts derived from the data), trend depth,
+    available dimensions, efficiency capability, cost model. Intended to be
+    called first by any well-behaved client so it does not over-promise.
+    """
+    info = discover_dataset(data_dir=data_dir)
+
+    scales_out: dict[str, dict[str, Any]] = {}
+    for scale_key, scale_info in info.scales.items():
+        scales_out[scale_key] = {
+            "granularity": scale_info.granularity,
+            "depth": scale_info.depth,
+            "points_per_namespace": scale_info.points_per_namespace,
+        }
+
+    trends_out: dict[str, Any] | None = None
+    if info.trends is not None:
+        trends_out = {
+            "granularity": info.trends.granularity,
+            "depth": info.trends.depth,
+            "points_per_namespace": info.trends.points_per_namespace,
+        }
+
+    # Convert the data_freshness ISO string back to a mtime for the metadata
+    # helper — keeps freshness warning logic centralised.
+    freshness_mtime: float | None = None
+    if info.data_freshness_utc is not None:
+        try:
+            freshness_mtime = datetime.fromisoformat(info.data_freshness_utc.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            freshness_mtime = None
+
+    return {
+        "metrics_available": info.metrics_available,
+        "gpu_available": info.gpu_available,
+        "scales": scales_out,
+        "trends": trends_out,
+        "dimensions": info.dimensions,
+        "efficiency": {
+            "aggregated": info.efficiency.aggregated,
+            "hourly_timeseries": info.efficiency.hourly_timeseries,
+        },
+        "cost_model": info.cost_model.cost_model if info.cost_model else None,
+        "currency": info.cost_model.currency if info.cost_model else None,
+        "billing_hourly_rate": info.billing_hourly_rate,
+        "data_freshness_utc": info.data_freshness_utc,
+        "metadata": build_metadata(
+            cost_model=info.cost_model,
+            warnings=info.warnings,
+            generated_at_mtime=freshness_mtime,
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Histogram loading & filtering helpers (shared by §4.2 tools)
+# ---------------------------------------------------------------------------
+
+
+def _is_special(name: str) -> bool:
+    return name in SPECIAL_ENTRIES
+
+
+def _is_system(name: str) -> bool:
+    return any(name.startswith(p) for p in SYSTEM_NAMESPACE_PREFIXES)
+
+
+def _validate_metric(metric: str) -> None:
+    if metric not in METRICS:
+        raise ValueError(f"unknown metric {metric!r}: expected one of {list(METRICS)}")
+
+
+def _validate_scale(scale: str) -> None:
+    if scale not in SCALE_TO_PERIOD:
+        raise ValueError(f"unknown scale {scale!r}: expected one of {list(SCALE_TO_PERIOD)}")
+
+
+def _load_histogram_payload(
+    metric: str,
+    scale: str,
+    dimension: str = "usage",
+    gpu: bool = False,
+    data_dir: Path | None = None,
+) -> tuple[list[dict[str, Any]] | None, str, float | None, str | None]:
+    """Load a histogram file by (metric, scale, dimension, gpu).
+
+    Returns:
+        ``(entries, filename, mtime_utc, error)``. ``entries`` is ``None``
+        when the file is missing, malformed, or has the wrong shape; the
+        caller surfaces ``error`` in the response so the client can decide.
+
+    """
+    period = SCALE_TO_PERIOD[scale]
+    fname = histogram_filename(metric, dimension, period, gpu=gpu)
+    result = read_json_file(fname, data_dir=data_dir)
+    if not result.ok:
+        return None, fname, result.mtime_utc, result.error
+    if not isinstance(result.payload, list):
+        return None, fname, result.mtime_utc, f"{fname}: expected JSON array at top level"
+    return result.payload, fname, result.mtime_utc, None
+
+
+def _unique_dates_in_order(entries: list[dict[str, Any]]) -> list[str]:
+    """Distinct ``date`` values in the order they first appear in the file.
+
+    backend.py emits entries in chronological order over RRD consolidated
+    data points, so the first occurrence order is chronological — taking
+    the last element here means "most recent date in the data".
+    """
+    seen: list[str] = []
+    seen_set: set = set()
+    for e in entries:
+        d = e.get("date")
+        if isinstance(d, str) and d not in seen_set:
+            seen.append(d)
+            seen_set.add(d)
+    return seen
+
+
+def _coerce_value(entry: dict[str, Any]) -> float | None:
+    """Extract the numeric usage value of an entry, or None if unusable."""
+    v = entry.get("usage")
+    if isinstance(v, (int, float)):
+        return float(v)
+    return None
+
+
+def _build_data_window(
+    scale: str,
+    dates_in_order: list[str],
+    selected_date: str | None = None,
+) -> dict[str, Any]:
+    """Assemble the ``data_window`` block for histogram-backed responses."""
+    if selected_date is not None:
+        return {
+            "granularity": SCALE_GRANULARITY[scale],
+            "start": selected_date,
+            "end": selected_date,
+            "points": 1,
+            "timezone": "UTC",
+        }
+    return {
+        "granularity": SCALE_GRANULARITY[scale],
+        "start": dates_in_order[0] if dates_in_order else None,
+        "end": dates_in_order[-1] if dates_in_order else None,
+        "points": len(dates_in_order),
+        "timezone": "UTC",
+    }
+
+
+def _round(value: float, decimals: int = 6) -> float:
+    return round(float(value), decimals)
+
+
+# ---------------------------------------------------------------------------
+# Tools — Consolidations group (spec §4.2)
+# ---------------------------------------------------------------------------
+
+
+def tool_get_usage(
+    metric: str,
+    scale: str,
+    namespace: str | None = None,
+    exclude_special: bool = True,
+    data_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Implement the ``get_usage`` MCP tool — usage per namespace.
+
+    Returns the time series ``{namespace, date, value}`` from the histogram
+    file for the requested (metric, scale). System namespaces are NOT
+    filtered (callers see them) — only special entries are excluded when
+    ``exclude_special`` is True (the default, per spec §2.4).
+    """
+    _validate_metric(metric)
+    _validate_scale(scale)
+
+    cost_model, warnings = load_cost_model(data_dir=data_dir)
+    entries, fname, mtime, err = _load_histogram_payload(
+        metric=metric,
+        scale=scale,
+        dimension="usage",
+        data_dir=data_dir,
+    )
+    if entries is None:
+        warnings.append(f"{fname}: {err or 'histogram unavailable'}")
+        return {
+            "metric": metric,
+            "scale": scale,
+            "namespace": namespace,
+            "series": [],
+            "metadata": build_metadata(
+                cost_model=cost_model,
+                warnings=warnings,
+                metric=metric,
+                scale=scale,
+                source_file=fname,
+                generated_at_mtime=mtime,
+            ),
+        }
+
+    series: list[dict[str, Any]] = []
+    for entry in entries:
+        stack = entry.get("stack")
+        if not isinstance(stack, str):
+            continue
+        if exclude_special and _is_special(stack):
+            continue
+        if namespace is not None and stack != namespace:
+            continue
+        value = _coerce_value(entry)
+        date_key = entry.get("date")
+        if value is None or not isinstance(date_key, str):
+            continue
+        series.append(
+            {
+                "namespace": stack,
+                "date": date_key,
+                "value": _round(value),
+            }
+        )
+
+    dates = _unique_dates_in_order(entries)
+    return {
+        "metric": metric,
+        "scale": scale,
+        "namespace": namespace,
+        "series": series,
+        "metadata": build_metadata(
+            cost_model=cost_model,
+            warnings=warnings,
+            metric=metric,
+            scale=scale,
+            data_window=_build_data_window(scale, dates),
+            source_file=fname,
+            generated_at_mtime=mtime,
+        ),
+    }
+
+
+def tool_get_top_consumers(
+    metric: str,
+    scale: str,
+    limit: int = 10,
+    exclude_system: bool = True,
+    date: str | None = None,
+    data_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Implement the ``get_top_consumers`` MCP tool.
+
+    Ranks namespaces by usage descending for the selected date (last
+    available by default). Special entries are ALWAYS excluded — letting
+    ``non-allocatable`` top the ranking would defeat the purpose (spec §2.4).
+    ``exclude_system`` only controls whether system namespaces appear.
+    """
+    _validate_metric(metric)
+    _validate_scale(scale)
+    if limit < 1:
+        raise ValueError(f"limit must be >= 1, got {limit}")
+
+    cost_model, warnings = load_cost_model(data_dir=data_dir)
+    entries, fname, mtime, err = _load_histogram_payload(
+        metric=metric,
+        scale=scale,
+        dimension="usage",
+        data_dir=data_dir,
+    )
+    if entries is None:
+        warnings.append(f"{fname}: {err or 'histogram unavailable'}")
+        return {
+            "metric": metric,
+            "scale": scale,
+            "date": date,
+            "ranking": [],
+            "metadata": build_metadata(
+                cost_model=cost_model,
+                warnings=warnings,
+                metric=metric,
+                scale=scale,
+                source_file=fname,
+                generated_at_mtime=mtime,
+            ),
+        }
+
+    dates = _unique_dates_in_order(entries)
+    target_date = date if date is not None else (dates[-1] if dates else None)
+    if target_date is None:
+        warnings.append(f"no date available in {fname}")
+        return {
+            "metric": metric,
+            "scale": scale,
+            "date": None,
+            "ranking": [],
+            "metadata": build_metadata(
+                cost_model=cost_model,
+                warnings=warnings,
+                metric=metric,
+                scale=scale,
+                source_file=fname,
+                generated_at_mtime=mtime,
+            ),
+        }
+    if date is not None and date not in dates:
+        warnings.append(f"date {date!r} not present in {fname} (available: {dates})")
+
+    candidates: list[tuple[str, float]] = []
+    for entry in entries:
+        if entry.get("date") != target_date:
+            continue
+        stack = entry.get("stack")
+        if not isinstance(stack, str):
+            continue
+        if _is_special(stack):
+            continue  # always excluded from rankings
+        if exclude_system and _is_system(stack):
+            continue
+        value = _coerce_value(entry)
+        if value is None:
+            continue
+        candidates.append((stack, value))
+
+    candidates.sort(key=lambda item: item[1], reverse=True)
+    total = sum(v for _, v in candidates)
+    effective_limit = min(limit, len(candidates))
+
+    ranking: list[dict[str, Any]] = []
+    for idx, (ns, value) in enumerate(candidates[:effective_limit], start=1):
+        share_pct = (100.0 * value / total) if total > 0 else 0.0
+        ranking.append(
+            {
+                "rank": idx,
+                "namespace": ns,
+                "value": _round(value),
+                "share_pct": round(share_pct, 2),
+            }
+        )
+
+    return {
+        "metric": metric,
+        "scale": scale,
+        "date": target_date,
+        "ranking": ranking,
+        "metadata": build_metadata(
+            cost_model=cost_model,
+            warnings=warnings,
+            metric=metric,
+            scale=scale,
+            data_window=_build_data_window(scale, dates, selected_date=target_date),
+            source_file=fname,
+            generated_at_mtime=mtime,
+        ),
+    }
+
+
+def tool_get_namespace_breakdown(
+    metric: str,
+    scale: str,
+    date: str | None = None,
+    exclude_system: bool = True,
+    data_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Implement the ``get_namespace_breakdown`` MCP tool.
+
+    Returns the full ranked breakdown of namespaces (not limited), plus
+    concentration indicators (top-3 / top-10 share) and a ``cluster_overhead``
+    block that surfaces ``non-allocatable`` separately — never mingled with
+    namespaces (spec §4.2). ``cluster_overhead.non_allocatable_share_pct``
+    and ``allocatable_share_pct`` are computed against the total cluster
+    (overhead + namespaces) and sum to 100 %.
+    """
+    _validate_metric(metric)
+    _validate_scale(scale)
+
+    cost_model, warnings = load_cost_model(data_dir=data_dir)
+    entries, fname, mtime, err = _load_histogram_payload(
+        metric=metric,
+        scale=scale,
+        dimension="usage",
+        data_dir=data_dir,
+    )
+    if entries is None:
+        warnings.append(f"{fname}: {err or 'histogram unavailable'}")
+        return {
+            "metric": metric,
+            "scale": scale,
+            "date": date,
+            "breakdown": [],
+            "concentration": {"top_3_share_pct": 0.0, "top_10_share_pct": 0.0, "total_namespaces": 0},
+            "cluster_overhead": None,
+            "metadata": build_metadata(
+                cost_model=cost_model,
+                warnings=warnings,
+                metric=metric,
+                scale=scale,
+                source_file=fname,
+                generated_at_mtime=mtime,
+            ),
+        }
+
+    dates = _unique_dates_in_order(entries)
+    target_date = date if date is not None else (dates[-1] if dates else None)
+    if target_date is None:
+        warnings.append(f"no date available in {fname}")
+        return {
+            "metric": metric,
+            "scale": scale,
+            "date": None,
+            "breakdown": [],
+            "concentration": {"top_3_share_pct": 0.0, "top_10_share_pct": 0.0, "total_namespaces": 0},
+            "cluster_overhead": None,
+            "metadata": build_metadata(
+                cost_model=cost_model,
+                warnings=warnings,
+                metric=metric,
+                scale=scale,
+                source_file=fname,
+                generated_at_mtime=mtime,
+            ),
+        }
+    if date is not None and date not in dates:
+        warnings.append(f"date {date!r} not present in {fname} (available: {dates})")
+
+    non_allocatable_value: float | None = None
+    namespace_values: list[tuple[str, float]] = []
+    for entry in entries:
+        if entry.get("date") != target_date:
+            continue
+        stack = entry.get("stack")
+        if not isinstance(stack, str):
+            continue
+        value = _coerce_value(entry)
+        if value is None:
+            continue
+        if stack == "non-allocatable":
+            non_allocatable_value = value
+            continue
+        if _is_special(stack):
+            continue  # never in breakdown
+        if exclude_system and _is_system(stack):
+            continue
+        namespace_values.append((stack, value))
+
+    namespace_values.sort(key=lambda item: item[1], reverse=True)
+    namespace_total = sum(v for _, v in namespace_values)
+
+    breakdown: list[dict[str, Any]] = []
+    for ns, value in namespace_values:
+        share_pct = (100.0 * value / namespace_total) if namespace_total > 0 else 0.0
+        breakdown.append(
+            {
+                "namespace": ns,
+                "value": _round(value),
+                "share_pct": round(share_pct, 2),
+            }
+        )
+
+    top_3_sum = sum(v for _, v in namespace_values[:3])
+    top_10_sum = sum(v for _, v in namespace_values[:10])
+    concentration = {
+        "top_3_share_pct": round(100.0 * top_3_sum / namespace_total, 2) if namespace_total > 0 else 0.0,
+        "top_10_share_pct": round(100.0 * top_10_sum / namespace_total, 2) if namespace_total > 0 else 0.0,
+        "total_namespaces": len(breakdown),
+    }
+
+    cluster_overhead: dict[str, Any] | None = None
+    if non_allocatable_value is not None:
+        total_cluster = non_allocatable_value + namespace_total
+        if total_cluster > 0:
+            cluster_overhead = {
+                "non_allocatable_value": _round(non_allocatable_value),
+                "non_allocatable_share_pct": round(100.0 * non_allocatable_value / total_cluster, 2),
+                "allocatable_share_pct": round(100.0 * namespace_total / total_cluster, 2),
+            }
+        else:
+            warnings.append("non-allocatable present but total cluster value is zero; cluster_overhead omitted")
+    else:
+        warnings.append(f"non-allocatable absent from data for date {target_date!r}; cluster_overhead omitted")
+
+    return {
+        "metric": metric,
+        "scale": scale,
+        "date": target_date,
+        "breakdown": breakdown,
+        "concentration": concentration,
+        "cluster_overhead": cluster_overhead,
+        "metadata": build_metadata(
+            cost_model=cost_model,
+            warnings=warnings,
+            metric=metric,
+            scale=scale,
+            data_window=_build_data_window(scale, dates, selected_date=target_date),
+            source_file=fname,
+            generated_at_mtime=mtime,
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tools — Efficiency group (spec §4.3)
+# ---------------------------------------------------------------------------
+
+
+def _classify_efficiency(ratio: float) -> str:
+    """Descriptive classification — never prescriptive (spec §4.3)."""
+    if ratio < EFFICIENCY_OVER_PROVISIONED_BELOW:
+        return "over_provisioned"
+    if ratio > EFFICIENCY_UNDER_PROVISIONED_ABOVE:
+        return "under_provisioned"
+    return "balanced"
+
+
+def _aggregate_by_namespace(
+    entries: list[dict[str, Any]],
+) -> dict[str, float]:
+    """Sum ``usage`` values per namespace across all dates, skipping specials."""
+    totals: dict[str, float] = collections.defaultdict(float)
+    for entry in entries:
+        stack = entry.get("stack")
+        if not isinstance(stack, str):
+            continue
+        if _is_special(stack):
+            continue
+        value = _coerce_value(entry)
+        if value is None:
+            continue
+        totals[stack] += value
+    return totals
+
+
+def tool_get_efficiency(
+    scale: str,
+    namespace: str | None = None,
+    metric: str | None = None,
+    data_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Implement the ``get_efficiency`` MCP tool.
+
+    Crosses the ``*_usage_*`` and ``*_requests_*`` histograms to compute the
+    ratio ``usage / requests`` per (namespace, metric) at scale level. The
+    ratio is **descriptive**: a classification ``over_provisioned`` /
+    ``balanced`` / ``under_provisioned`` is provided but no recommendation
+    is made (spec §4.3).
+
+    Tolerance to zero (§4.3): ``requests`` is derived from ``usage / rf``,
+    so a high ``rf`` produces an infinitesimal — not strictly zero —
+    aggregate. Any aggregate below :data:`REQUESTS_ZERO_THRESHOLD` is
+    treated as zero; the ratio becomes ``null`` and a warning is added.
+    """
+    _validate_scale(scale)
+    if metric is not None:
+        _validate_metric(metric)
+
+    metrics_filter = [metric] if metric is not None else list(METRICS)
+
+    cost_model, warnings = load_cost_model(data_dir=data_dir)
+    efficiency: list[dict[str, Any]] = []
+    source_files: list[str] = []
+    latest_mtime: float | None = None
+    data_window: dict[str, Any] | None = None
+
+    for current_metric in metrics_filter:
+        usage_entries, usage_fname, usage_mtime, usage_err = _load_histogram_payload(
+            metric=current_metric,
+            scale=scale,
+            dimension="usage",
+            data_dir=data_dir,
+        )
+        if usage_entries is None:
+            warnings.append("{}: {}".format(usage_fname, usage_err or "unavailable"))
+            continue
+        source_files.append(usage_fname)
+        if usage_mtime is not None:
+            latest_mtime = usage_mtime if latest_mtime is None else max(latest_mtime, usage_mtime)
+
+        req_entries, req_fname, req_mtime, req_err = _load_histogram_payload(
+            metric=current_metric,
+            scale=scale,
+            dimension="requests",
+            data_dir=data_dir,
+        )
+        if req_entries is None:
+            warnings.append("{}: {}".format(req_fname, req_err or "unavailable"))
+            continue
+        source_files.append(req_fname)
+        if req_mtime is not None:
+            latest_mtime = req_mtime if latest_mtime is None else max(latest_mtime, req_mtime)
+
+        # Capture the data window once — both files share the same dates by
+        # construction (backend.py:1141 — same iteration over usage dates).
+        if data_window is None:
+            dates = _unique_dates_in_order(usage_entries)
+            data_window = _build_data_window(scale, dates)
+
+        usage_totals = _aggregate_by_namespace(usage_entries)
+        requests_totals = _aggregate_by_namespace(req_entries)
+
+        all_namespaces = set(usage_totals) | set(requests_totals)
+        if namespace is not None:
+            if namespace not in all_namespaces:
+                warnings.append(f"namespace {namespace!r} not present in {current_metric} histograms")
+                continue
+            all_namespaces = {namespace}
+
+        for ns in sorted(all_namespaces):
+            usage_value = usage_totals.get(ns, 0.0)
+            requests_value = requests_totals.get(ns, 0.0)
+
+            if requests_value < REQUESTS_ZERO_THRESHOLD:
+                ratio: float | None = None
+                classification: str | None = None
+                warnings.append(
+                    f"{ns}/{current_metric}: requests aggregate below {REQUESTS_ZERO_THRESHOLD:g} threshold; "
+                    "efficiency_ratio set to null"
+                )
+            else:
+                ratio = usage_value / requests_value
+                classification = _classify_efficiency(ratio)
+
+            efficiency.append(
+                {
+                    "namespace": ns,
+                    "metric": current_metric,
+                    "usage": _round(usage_value),
+                    "requests": _round(requests_value),
+                    "efficiency_ratio": _round(ratio) if ratio is not None else None,
+                    "classification": classification,
+                }
+            )
+
+    # Stable order: (namespace, metric) — same namespace's metrics stay adjacent.
+    efficiency.sort(key=lambda e: (e["namespace"], e["metric"]))
+
+    # source_file is a single string in the metadata block — join the
+    # contributing files so the trail is preserved without changing shape.
+    source_file = ", ".join(source_files) if source_files else None
+
+    return {
+        "scale": scale,
+        "namespace": namespace,
+        "metric": metric,
+        "efficiency": efficiency,
+        "metadata": build_metadata(
+            cost_model=cost_model,
+            warnings=warnings,
+            scale=scale,
+            metric=metric,
+            data_window=data_window,
+            source_file=source_file,
+            generated_at_mtime=latest_mtime,
+            # The headline number in this response is a dimensionless ratio.
+            # Override the cost_model-derived unit so clients don't mistake
+            # the ratio for the cost_model's unit.
+            unit_override="efficiency_ratio",
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tools — Trends group (spec §4.4)
+# ---------------------------------------------------------------------------
+
+
+def _validate_namespace(namespace: str) -> None:
+    if not isinstance(namespace, str) or not namespace:
+        raise ValueError("namespace must be a non-empty string")
+
+
+def _load_trends_payload(
+    metric: str,
+    category: str = "usage",
+    gpu: bool = False,
+    data_dir: Path | None = None,
+) -> tuple[list[dict[str, Any]] | None, str, float | None, str | None]:
+    """Load a trends file by (metric, category, gpu).
+
+    backend.py emits ``*_<category>_trends.json`` with hourly entries
+    ``{name, dateUTC, usage}`` over a 7-day window. The value field is named
+    ``usage`` even in ``*_rf_trends.json`` (it carries the efficiency ratio
+    there — the filename, not the field, encodes the semantics; spec §2.2).
+    """
+    fname = trends_filename(metric, category, gpu=gpu)
+    result = read_json_file(fname, data_dir=data_dir)
+    if not result.ok:
+        return None, fname, result.mtime_utc, result.error
+    if not isinstance(result.payload, list):
+        return None, fname, result.mtime_utc, f"{fname}: expected JSON array at top level"
+    return result.payload, fname, result.mtime_utc, None
+
+
+def _filter_trends_namespace(
+    entries: list[dict[str, Any]],
+    namespace: str,
+) -> tuple[list[dict[str, Any]], list[float]]:
+    """Extract ``(series, raw_values)`` for one namespace from trends entries.
+
+    Preserves the file order — backend.py emits points chronologically per
+    namespace, so the resulting series is monotonic in time without an
+    explicit sort.
+    """
+    series: list[dict[str, Any]] = []
+    values: list[float] = []
+    for entry in entries:
+        if entry.get("name") != namespace:
+            continue
+        dt = entry.get("dateUTC")
+        v = entry.get("usage")
+        if not isinstance(dt, str) or not isinstance(v, (int, float)):
+            continue
+        value = float(v)
+        series.append({"dateUTC": dt, "usage": _round(value)})
+        values.append(value)
+    return series, values
+
+
+def _compute_trend_stats(
+    series: list[dict[str, Any]],
+    values: list[float],
+) -> dict[str, Any]:
+    """Min / max / mean / window bounds for a timeseries — null when empty."""
+    if not values or not series:
+        return {
+            "min": None,
+            "max": None,
+            "mean": None,
+            "points": 0,
+            "window_start_utc": None,
+            "window_end_utc": None,
+        }
+    return {
+        "min": _round(min(values)),
+        "max": _round(max(values)),
+        "mean": _round(sum(values) / len(values)),
+        "points": len(values),
+        "window_start_utc": series[0]["dateUTC"],
+        "window_end_utc": series[-1]["dateUTC"],
+    }
+
+
+def _trends_data_window(stats: dict[str, Any]) -> dict[str, Any] | None:
+    if stats["points"] <= 0:
+        return None
+    return {
+        "granularity": "hourly",
+        "start": stats["window_start_utc"],
+        "end": stats["window_end_utc"],
+        "points": stats["points"],
+        "timezone": "UTC",
+    }
+
+
+def _classify_trend(values: list[float]) -> str:
+    """Return an indicative direction for a monthly series — descriptive only.
+
+    Splits the series into halves and compares means with a 10 % relative
+    threshold against the first half's magnitude. Returns one of
+    ``"growing"``, ``"stable"``, ``"decreasing"``, or ``"insufficient_data"``
+    when there are fewer than two points.
+    """
+    if len(values) < 2:
+        return "insufficient_data"
+    mid = len(values) // 2
+    first_half = values[:mid]
+    second_half = values[mid:]
+    if not first_half or not second_half:
+        return "insufficient_data"
+    first_mean = sum(first_half) / len(first_half)
+    second_mean = sum(second_half) / len(second_half)
+    if first_mean == 0:
+        # Usage values in this domain are non-negative (sum of RRD CDPs
+        # rounded to 6 decimals — see backend.py:dump_histogram_analytics),
+        # so second_mean is either zero (stable) or positive (growing).
+        return "growing" if second_mean > 0 else "stable"
+    delta_ratio = (second_mean - first_mean) / abs(first_mean)
+    if delta_ratio > TREND_CHANGE_THRESHOLD:
+        return "growing"
+    if delta_ratio < -TREND_CHANGE_THRESHOLD:
+        return "decreasing"
+    return "stable"
+
+
+def tool_get_timeseries(
+    metric: str,
+    namespace: str,
+    data_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Implement the ``get_timeseries`` MCP tool.
+
+    Returns the hourly usage series over the trends window (~7 days in v1)
+    for a single namespace, plus simple pre-computed statistics. Depth is
+    derived from the data — not hard-coded — so the response stays accurate
+    if backend.py later widens or narrows the trends retention.
+    """
+    _validate_metric(metric)
+    _validate_namespace(namespace)
+
+    cost_model, warnings = load_cost_model(data_dir=data_dir)
+    entries, fname, mtime, err = _load_trends_payload(
+        metric=metric,
+        category="usage",
+        data_dir=data_dir,
+    )
+    if entries is None:
+        warnings.append("{}: {}".format(fname, err or "unavailable"))
+        empty_stats = _compute_trend_stats([], [])
+        return {
+            "namespace": namespace,
+            "metric": metric,
+            "series": [],
+            "stats": empty_stats,
+            "metadata": build_metadata(
+                cost_model=cost_model,
+                warnings=warnings,
+                metric=metric,
+                source_file=fname,
+                generated_at_mtime=mtime,
+            ),
+        }
+
+    series, values = _filter_trends_namespace(entries, namespace=namespace)
+    if not series:
+        warnings.append(f"namespace {namespace!r} not present in {fname} (no data points)")
+    stats = _compute_trend_stats(series, values)
+
+    return {
+        "namespace": namespace,
+        "metric": metric,
+        "series": series,
+        "stats": stats,
+        "metadata": build_metadata(
+            cost_model=cost_model,
+            warnings=warnings,
+            metric=metric,
+            data_window=_trends_data_window(stats),
+            source_file=fname,
+            generated_at_mtime=mtime,
+        ),
+    }
+
+
+def tool_get_efficiency_timeseries(
+    metric: str,
+    namespace: str,
+    data_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Implement the ``get_efficiency_timeseries`` MCP tool.
+
+    Same shape as :func:`tool_get_timeseries`, sourced from
+    ``*_rf_trends.json``. The numeric value at each hour is the efficiency
+    factor (``rf = usage / requests``) — not bounded by 1; values > 1 mean
+    usage exceeds requests (under-provisioning), per spec §4.4. The unit
+    in the metadata is set to ``efficiency_ratio`` so the client cannot
+    confuse it with the cost_model's unit.
+    """
+    _validate_metric(metric)
+    _validate_namespace(namespace)
+
+    cost_model, warnings = load_cost_model(data_dir=data_dir)
+    entries, fname, mtime, err = _load_trends_payload(
+        metric=metric,
+        category="rf",
+        data_dir=data_dir,
+    )
+    if entries is None:
+        warnings.append("{}: {}".format(fname, err or "unavailable"))
+        empty_stats = _compute_trend_stats([], [])
+        return {
+            "namespace": namespace,
+            "metric": metric,
+            "series": [],
+            "stats": empty_stats,
+            "metadata": build_metadata(
+                cost_model=cost_model,
+                warnings=warnings,
+                metric=metric,
+                source_file=fname,
+                generated_at_mtime=mtime,
+                unit_override="efficiency_ratio",
+            ),
+        }
+
+    series, values = _filter_trends_namespace(entries, namespace=namespace)
+    if not series:
+        warnings.append(f"namespace {namespace!r} not present in {fname} (no data points)")
+    stats = _compute_trend_stats(series, values)
+
+    return {
+        "namespace": namespace,
+        "metric": metric,
+        "series": series,
+        "stats": stats,
+        "metadata": build_metadata(
+            cost_model=cost_model,
+            warnings=warnings,
+            metric=metric,
+            data_window=_trends_data_window(stats),
+            source_file=fname,
+            generated_at_mtime=mtime,
+            unit_override="efficiency_ratio",
+        ),
+    }
+
+
+def _namespace_monthly_trajectory(
+    entries: list[dict[str, Any]],
+    namespace: str,
+) -> tuple[list[dict[str, Any]], list[float]]:
+    """Per-namespace monthly series from a year-window histogram payload."""
+    series: list[dict[str, Any]] = []
+    values: list[float] = []
+    for entry in entries:
+        if entry.get("stack") != namespace:
+            continue
+        d = entry.get("date")
+        v = _coerce_value(entry)
+        if not isinstance(d, str) or v is None:
+            continue
+        series.append({"date": d, "value": _round(v)})
+        values.append(v)
+    return series, values
+
+
+def _namespace_period_aggregate(
+    entries: list[dict[str, Any]],
+    namespace: str,
+) -> tuple[float, list[str]]:
+    """Sum a namespace's values across a histogram + return distinct dates."""
+    total = 0.0
+    dates: list[str] = []
+    seen: set = set()
+    for entry in entries:
+        if entry.get("stack") != namespace:
+            continue
+        v = _coerce_value(entry)
+        if v is None:
+            continue
+        total += v
+        d = entry.get("date")
+        if isinstance(d, str) and d not in seen:
+            dates.append(d)
+            seen.add(d)
+    return total, dates
+
+
+def tool_compare_periods(
+    metric: str,
+    namespace: str,
+    data_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Implement the ``compare_periods`` MCP tool.
+
+    Reads the 14-day daily histogram and the year-window monthly histogram
+    for a single namespace and presents both side-by-side: aggregate over
+    14 days, plus the monthly trajectory with a descriptive direction
+    (growing / stable / decreasing / insufficient_data). Strictly
+    descriptive — no prediction is attempted (spec §4.4).
+    """
+    _validate_metric(metric)
+    _validate_namespace(namespace)
+
+    cost_model, warnings = load_cost_model(data_dir=data_dir)
+
+    daily_entries, daily_fname, daily_mtime, daily_err = _load_histogram_payload(
+        metric=metric,
+        scale=SCALE_DAILY_14D,
+        dimension="usage",
+        data_dir=data_dir,
+    )
+    monthly_entries, monthly_fname, monthly_mtime, monthly_err = _load_histogram_payload(
+        metric=metric,
+        scale=SCALE_MONTHLY_12M,
+        dimension="usage",
+        data_dir=data_dir,
+    )
+
+    daily_block: dict[str, Any] | None = None
+    if daily_entries is None:
+        warnings.append("{}: {}".format(daily_fname, daily_err or "unavailable"))
+    else:
+        total, dates = _namespace_period_aggregate(daily_entries, namespace)
+        if not dates:
+            warnings.append(f"namespace {namespace!r} not present in {daily_fname}")
+        daily_block = {
+            "aggregate": _round(total),
+            "window_start": dates[0] if dates else None,
+            "window_end": dates[-1] if dates else None,
+            "points": len(dates),
+        }
+
+    monthly_block: dict[str, Any] | None = None
+    if monthly_entries is None:
+        warnings.append("{}: {}".format(monthly_fname, monthly_err or "unavailable"))
+    else:
+        series, values = _namespace_monthly_trajectory(monthly_entries, namespace)
+        if not series:
+            warnings.append(f"namespace {namespace!r} not present in {monthly_fname}")
+        monthly_block = {
+            "series": series,
+            "trend_direction": _classify_trend(values),
+        }
+
+    latest_mtime: float | None = None
+    for mt in (daily_mtime, monthly_mtime):
+        if mt is not None:
+            latest_mtime = mt if latest_mtime is None else max(latest_mtime, mt)
+    source_files = [f for f in (daily_fname, monthly_fname) if f]
+    source_file = ", ".join(source_files) if source_files else None
+
+    return {
+        "namespace": namespace,
+        "metric": metric,
+        "daily_14d": daily_block,
+        "monthly_12m": monthly_block,
+        "metadata": build_metadata(
+            cost_model=cost_model,
+            warnings=warnings,
+            metric=metric,
+            source_file=source_file,
+            generated_at_mtime=latest_mtime,
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tools — Utility group (spec §4.5)
+# ---------------------------------------------------------------------------
+
+
+def tool_group_namespaces(
+    metric: str,
+    scale: str,
+    pattern: str,
+    date: str | None = None,
+    data_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Implement the ``group_namespaces`` MCP tool.
+
+    Aggregates namespaces whose names match a glob ``pattern`` (Unix-style,
+    backed by :mod:`fnmatch` — same convention as backend.py uses for its
+    include/exclude lists). Returns the group's total, the matched count,
+    and a per-member breakdown sorted by value descending.
+
+    Special entries (``non-allocatable``, ``.billing-hourly-rate``) are
+    always excluded — letting them match a wildcard like ``*`` would inflate
+    the group total with non-usage values (spec §2.4).
+    """
+    _validate_metric(metric)
+    _validate_scale(scale)
+    if not isinstance(pattern, str) or not pattern:
+        raise ValueError("pattern must be a non-empty string")
+    if len(pattern) > GROUP_PATTERN_MAX_LENGTH:
+        raise ValueError(
+            f"pattern length {len(pattern)} exceeds maximum of {GROUP_PATTERN_MAX_LENGTH}",
+        )
+
+    cost_model, warnings = load_cost_model(data_dir=data_dir)
+    entries, fname, mtime, err = _load_histogram_payload(
+        metric=metric,
+        scale=scale,
+        dimension="usage",
+        data_dir=data_dir,
+    )
+    if entries is None:
+        warnings.append("{}: {}".format(fname, err or "unavailable"))
+        return {
+            "metric": metric,
+            "scale": scale,
+            "pattern": pattern,
+            "date": date,
+            "group_total": 0.0,
+            "matched_count": 0,
+            "members": [],
+            "metadata": build_metadata(
+                cost_model=cost_model,
+                warnings=warnings,
+                metric=metric,
+                scale=scale,
+                source_file=fname,
+                generated_at_mtime=mtime,
+            ),
+        }
+
+    dates = _unique_dates_in_order(entries)
+    target_date = date if date is not None else (dates[-1] if dates else None)
+    if target_date is None:
+        warnings.append(f"no date available in {fname}")
+        return {
+            "metric": metric,
+            "scale": scale,
+            "pattern": pattern,
+            "date": None,
+            "group_total": 0.0,
+            "matched_count": 0,
+            "members": [],
+            "metadata": build_metadata(
+                cost_model=cost_model,
+                warnings=warnings,
+                metric=metric,
+                scale=scale,
+                source_file=fname,
+                generated_at_mtime=mtime,
+            ),
+        }
+    if date is not None and date not in dates:
+        warnings.append(f"date {date!r} not present in {fname} (available: {dates})")
+
+    members_map: dict[str, float] = {}
+    for entry in entries:
+        if entry.get("date") != target_date:
+            continue
+        stack = entry.get("stack")
+        if not isinstance(stack, str):
+            continue
+        if _is_special(stack):
+            continue
+        if not fnmatch.fnmatch(stack, pattern):
+            continue
+        value = _coerce_value(entry)
+        if value is None:
+            continue
+        # If multiple entries somehow share (stack, date), sum them.
+        members_map[stack] = members_map.get(stack, 0.0) + value
+
+    members = [
+        {"namespace": ns, "value": _round(v)}
+        for ns, v in sorted(members_map.items(), key=lambda item: item[1], reverse=True)
+    ]
+    group_total = sum(v for v in members_map.values())
+
+    if not members:
+        warnings.append(f"pattern {pattern!r} matched no namespace at date {target_date!r}")
+
+    return {
+        "metric": metric,
+        "scale": scale,
+        "pattern": pattern,
+        "date": target_date,
+        "group_total": _round(group_total),
+        "matched_count": len(members),
+        "members": members,
+        "metadata": build_metadata(
+            cost_model=cost_model,
+            warnings=warnings,
+            metric=metric,
+            scale=scale,
+            data_window=_build_data_window(scale, dates, selected_date=target_date),
+            source_file=fname,
+            generated_at_mtime=mtime,
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# MCP wiring (spec §7.2 step 8) — protocol layer, transport, entry point
+# ---------------------------------------------------------------------------
+#
+# The tool_* functions above are plain Python: they take native Python args,
+# return native Python dicts, and have no MCP dependency. This last section
+# is the thin adapter that:
+#
+# - registers each tool with the MCP SDK via FastMCP (it auto-generates the
+#   ``inputSchema`` from type annotations);
+# - exposes the tools over the Streamable HTTP transport (spec §3.4 — the
+#   single endpoint ``/mcp`` is what the K8s Service publishes; SSE and
+#   stdio are intentionally not supported, see ``main()`` docstring);
+# - detects whether the SDK supports ``structuredContent`` /
+#   ``outputSchema`` and logs which mechanism is in effect (spec §4.7).
+#
+# MCP SDK and its transitive deps (starlette, uvicorn, anyio) are listed in
+# pyproject.toml. They are only required when the MCP container starts;
+# importing them lazily here means the rest of the module remains usable in
+# isolation (e.g. when unit-testing the tool_* functions on a machine
+# without the SDK installed).
+#
+# Note on response shape — FastMCP convention. When a tool returns a generic
+# ``Dict[str, Any]`` (rather than a Pydantic model), the SDK wraps the value
+# under a ``"result"`` key in ``structuredContent``. So the JSON shape the
+# client receives is:
+#
+#     {
+#       "content": [{"type": "text", "text": "<json-encoded tool dict>"}],
+#       "structuredContent": {"result": { ...tool dict... }}
+#     }
+#
+# The unwrapped spec-shape (§4.1–§4.5) is therefore reachable two ways:
+# parsing ``content[0].text`` (text fallback, always present) or navigating
+# ``structuredContent.result.*``. Both carry identical data — and both
+# include the ``metadata`` block. This is a deliberate FastMCP safety
+# convention, not a spec violation; clients are expected to handle it.
+
+
+_MCP_TOOL_REGISTRY: list[tuple[str, Any]] = [
+    # (mcp_tool_name, underlying tool_* function). Used for diagnostics and
+    # for the lazy-built FastMCP app below.
+]
+
+
+def _build_mcp_app() -> Any:
+    """Build and configure the FastMCP application — done lazily.
+
+    Kept lazy so importing ``mcp_server`` does NOT require the ``mcp`` SDK
+    to be installed; only :func:`main` triggers it. This is also what
+    keeps the unit tests (which never call main()) light.
+    """
+    from mcp.server.fastmcp import FastMCP
+
+    host = _get_env("MCP_LISTEN_HOST", "0.0.0.0") or "0.0.0.0"
+    try:
+        port = int(_get_env("MCP_LISTEN_PORT", "5484") or "5484")
+    except (TypeError, ValueError):
+        port = 5484
+
+    app = FastMCP(
+        name="kubeledger-mcp",
+        instructions=(
+            "Read-only descriptive surface over KubeLedger analytics. "
+            "Exposes namespace usage, top consumers, breakdown with cluster "
+            "overhead, efficiency (aggregated and hourly), trends, and "
+            "regrouping by glob pattern. Every response carries a metadata "
+            "block with cost_model, unit, data window and warnings — call "
+            "describe_dataset first to learn what is available."
+        ),
+        host=host,
+        port=port,
+    )
+
+    # --- Tools registration ---------------------------------------------
+    #
+    # Each registration is a thin wrapper around the corresponding pure
+    # Python ``tool_*`` function. The annotations on the wrapper determine
+    # the JSON Schema that FastMCP advertises to clients, so:
+    #   - Use ``Literal[...]`` for the values that the spec constrains
+    #     (metric, scale) — clients get a strict enum at the protocol level.
+    #   - Use ``Optional[str]`` for free-form optional strings (namespace,
+    #     date, pattern when allowed null) so they appear as nullable.
+    #   - Return ``Dict[str, Any]`` — FastMCP serialises and (when the SDK
+    #     supports it) puts the result under ``structuredContent``.
+
+    @app.tool()
+    def list_namespaces() -> dict[str, Any]:
+        """List available namespaces (application / system) and the known special entries."""
+        return tool_list_namespaces()
+
+    @app.tool()
+    def describe_dataset() -> dict[str, Any]:
+        """Announce dataset capabilities: metrics, GPU availability, scales, efficiency, cost_model."""
+        return tool_describe_dataset()
+
+    @app.tool()
+    def get_usage(
+        metric: Literal["cpu", "memory"],
+        scale: Literal["daily_14d", "monthly_12m"],
+        namespace: str | None = None,
+        exclude_special: bool = True,
+    ) -> dict[str, Any]:
+        """Usage per namespace for a given metric and scale (time series of points)."""
+        return tool_get_usage(
+            metric=metric,
+            scale=scale,
+            namespace=namespace,
+            exclude_special=exclude_special,
+        )
+
+    @app.tool()
+    def get_top_consumers(
+        metric: Literal["cpu", "memory"],
+        scale: Literal["daily_14d", "monthly_12m"],
+        limit: int = 10,
+        exclude_system: bool = True,
+        date: str | None = None,
+    ) -> dict[str, Any]:
+        """Rank namespaces by usage for a date (defaults to the most recent in the data)."""
+        return tool_get_top_consumers(
+            metric=metric,
+            scale=scale,
+            limit=limit,
+            exclude_system=exclude_system,
+            date=date,
+        )
+
+    @app.tool()
+    def get_namespace_breakdown(
+        metric: Literal["cpu", "memory"],
+        scale: Literal["daily_14d", "monthly_12m"],
+        date: str | None = None,
+        exclude_system: bool = True,
+    ) -> dict[str, Any]:
+        """Proportional breakdown + concentration + cluster_overhead (non-allocatable separated)."""
+        return tool_get_namespace_breakdown(
+            metric=metric,
+            scale=scale,
+            date=date,
+            exclude_system=exclude_system,
+        )
+
+    @app.tool()
+    def get_efficiency(
+        scale: Literal["daily_14d", "monthly_12m"],
+        namespace: str | None = None,
+        metric: Literal["cpu", "memory"] | None = None,
+    ) -> dict[str, Any]:
+        """Return usage/requests ratio per (namespace, metric) — descriptive classification."""
+        return tool_get_efficiency(scale=scale, namespace=namespace, metric=metric)
+
+    @app.tool()
+    def get_timeseries(
+        metric: Literal["cpu", "memory"],
+        namespace: str,
+    ) -> dict[str, Any]:
+        """Hourly usage series over the trends window for a single namespace, with min/max/mean."""
+        return tool_get_timeseries(metric=metric, namespace=namespace)
+
+    @app.tool()
+    def compare_periods(
+        metric: Literal["cpu", "memory"],
+        namespace: str,
+    ) -> dict[str, Any]:
+        """Compare 14-day aggregate against monthly trajectory; descriptive trend direction."""
+        return tool_compare_periods(metric=metric, namespace=namespace)
+
+    @app.tool()
+    def get_efficiency_timeseries(
+        metric: Literal["cpu", "memory"],
+        namespace: str,
+    ) -> dict[str, Any]:
+        """Hourly efficiency factor (rf = usage/requests) series — not bounded at 1."""
+        return tool_get_efficiency_timeseries(metric=metric, namespace=namespace)
+
+    @app.tool()
+    def group_namespaces(
+        metric: Literal["cpu", "memory"],
+        scale: Literal["daily_14d", "monthly_12m"],
+        pattern: str,
+        date: str | None = None,
+    ) -> dict[str, Any]:
+        """Aggregate namespaces matching a glob pattern (fnmatch) — sum + per-member detail."""
+        return tool_group_namespaces(
+            metric=metric,
+            scale=scale,
+            pattern=pattern,
+            date=date,
+        )
+
+    # Register the metadata for diagnostics. Names match the wrapper
+    # functions defined above so the registry stays in sync with the SDK.
+    _MCP_TOOL_REGISTRY.clear()
+    for name in (
+        "list_namespaces",
+        "describe_dataset",
+        "get_usage",
+        "get_top_consumers",
+        "get_namespace_breakdown",
+        "get_efficiency",
+        "get_timeseries",
+        "compare_periods",
+        "get_efficiency_timeseries",
+        "group_namespaces",
+    ):
+        _MCP_TOOL_REGISTRY.append((name, globals().get("tool_" + name)))
+
+    return app
+
+
+def detect_structured_content_support() -> tuple[bool, str]:
+    """Detect whether the installed MCP SDK supports ``structuredContent``.
+
+    Spec §4.7 mandates that the wiring step verifies SDK capabilities and
+    signals the retained mode to the developer. We probe two markers:
+
+    1. the presence of a ``structuredContent`` field on the SDK's
+       ``CallToolResult`` model (added with protocol revision 2025-03),
+    2. the presence of ``outputSchema`` on the ``Tool`` model.
+
+    FastMCP automatically routes return values through ``structuredContent``
+    when the underlying SDK exposes it, falling back to a serialized text
+    block otherwise — so detection here is informational. Returns
+    ``(supported, human_readable_reason)``.
+    """
+    try:
+        import mcp as _mcp_pkg
+        from mcp.types import CallToolResult, Tool  # type: ignore[attr-defined]
+    except ImportError as exc:
+        return False, f"mcp SDK not importable: {exc}"
+
+    sdk_version = getattr(_mcp_pkg, "__version__", "unknown")
+
+    def _has_field(model: Any, name: str) -> bool:
+        fields = getattr(model, "model_fields", None) or getattr(model, "__fields__", None) or {}
+        return name in fields
+
+    has_structured = _has_field(CallToolResult, "structuredContent")
+    has_output_schema = _has_field(Tool, "outputSchema")
+
+    if has_structured and has_output_schema:
+        return True, f"mcp SDK {sdk_version}: structuredContent + outputSchema both present"
+    if has_structured:
+        return True, f"mcp SDK {sdk_version}: structuredContent present, outputSchema missing"
+    return False, f"mcp SDK {sdk_version}: structuredContent not supported — falling back to text content"
+
+
+def main() -> None:
+    """Run the KubeLedger MCP server over Streamable HTTP.
+
+    Single transport by design (spec §3.3 / §3.4): KubeLedger's MCP server
+    is meant to live inside a Kubernetes pod alongside backend.py, behind
+    a Service. Streamable HTTP is the modern transport that all current
+    MCP clients (Claude Desktop, Claude Code, MCP Inspector) speak.
+
+    SSE was the historical transport — now deprecated and removed here to
+    avoid a second code path that no current client needs. stdio was only
+    relevant for the ``.mcpb`` bundle pattern (data shipped locally), which
+    does not fit KubeLedger's "data generated in-cluster" model. Both have
+    been dropped in v1 to keep the surface minimal and the deployment
+    story coherent.
+    """
+    import logging
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    logger = logging.getLogger("kubeledger-mcp")
+
+    data_dir = get_data_dir()
+    host = _get_env("MCP_LISTEN_HOST", "0.0.0.0") or "0.0.0.0"
+    try:
+        port = int(_get_env("MCP_LISTEN_PORT", "5484") or "5484")
+    except ValueError:
+        port = 5484
+
+    logger.info(
+        "kubeledger-mcp starting on %s:%d (data_dir=%s, exists=%s)",
+        host,
+        port,
+        data_dir,
+        data_dir.is_dir(),
+    )
+    if host in ("0.0.0.0", "::", "*"):
+        # MCP v1 has no authentication at the tool layer (spec §3.5).
+        # Wide-open binding is fine when the pod is protected by the chart's
+        # default-deny NetworkPolicy, but risky on a bare host — surface it
+        # so operators don't deploy outside that envelope by accident.
+        logger.warning(
+            "binding on %s — server is reachable from any reachable interface. "
+            "MCP v1 has no auth; rely on NetworkPolicy / firewall.",
+            host,
+        )
+
+    supported, reason = detect_structured_content_support()
+    if supported:
+        logger.info("structuredContent: ENABLED — %s", reason)
+    else:
+        logger.info("structuredContent: DISABLED — %s", reason)
+
+    app = _build_mcp_app()
+    logger.info("registered %d MCP tools: %s", len(_MCP_TOOL_REGISTRY), ", ".join(n for n, _ in _MCP_TOOL_REGISTRY))
+    logger.info("transport: streamable-http (endpoint: /mcp)")
+
+    # Hand off to FastMCP's native ASGI transport. It internally builds a
+    # Starlette app and runs it with uvicorn — no custom ASGI plumbing
+    # needed (spec §3.3 / §7.3).
+    app.run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     # by the helm chart when mcp.enabled=true; see docs/kubeledger-mcp-spec.md).
     # The SDK pulls in starlette + uvicorn + anyio as transitive deps for the
     # SSE/HTTP transport — no need to list them explicitly.
-    "mcp>=1.0",
+    "mcp>=1.27.1",
 ]
 authors = [{ name = "Rodrigue Chakode", email = "rodrigue.chakode@gmail.com" }]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kubeledger"
-version = "26.01.1"
+version = "26.05.0-b1"
 description = "Open source Kubernetes resource usage tracking, accounting and optimization — CPU, memory, and GPU usage"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -13,6 +13,11 @@ dependencies = [
     "waitress>=3.0.2",
     "urllib3>=2.6.3",
     "werkzeug>=3.1.5",
+    # MCP server (optional sidecar — built into the image but only activated
+    # by the helm chart when mcp.enabled=true; see docs/kubeledger-mcp-spec.md).
+    # The SDK pulls in starlette + uvicorn + anyio as transitive deps for the
+    # SSE/HTTP transport — no need to list them explicitly.
+    "mcp>=1.0",
 ]
 authors = [{ name = "Rodrigue Chakode", email = "rodrigue.chakode@gmail.com" }]
 
@@ -37,7 +42,7 @@ dev = ["pytest", "ruff"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py38"
+target-version = "py312"
 
 [tool.ruff.lint]
 select = [
@@ -47,8 +52,9 @@ select = [
     "D",   # pydocstyle
     "G",   # flake8-logging-format
     "C90", # mccabe (complexity)
-    "PIE",  # flake8-pie
-    "SIM",  # flake8-simplify
+    "PIE", # flake8-pie
+    "SIM", # flake8-simplify
+    "UP",  # pyupgrade — modernise type hints + string formatting
 ]
 
 ignore = [

--- a/test_backend.py
+++ b/test_backend.py
@@ -11,7 +11,7 @@ __status__ = "Production"
 import backend
 
 
-class TestDecodeK8sMetrics(object):
+class TestDecodeK8sMetrics:
     def test_decode_cpu_capacity_nounit(self):
         assert round(backend.K8sUsage().decode_capacity("1"), 0) == 1
         assert round(backend.K8sUsage().decode_capacity("64"), 0) == 64

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest configuration for tests/ — adds the repo root to sys.path.
+
+Lets tests under tests/ import modules placed at the repository root
+(``mcp_server``, etc.) the same way ``test_backend.py`` already does
+from the root itself.
+"""
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,2149 @@
+#!/usr/bin/env python
+"""Tests for the KubeLedger MCP server.
+
+Covers step 1 of the implementation plan: data access layer (env-based path
+resolution, robust JSON parsing).
+"""
+
+import json
+import os
+from datetime import datetime, timedelta, UTC
+from pathlib import Path
+
+import pytest
+
+import mcp_server
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+class TestGetDataDir:
+    def test_default_when_no_env(self, monkeypatch):
+        monkeypatch.delenv("KL_MCP_DATA_DIR", raising=False)
+        monkeypatch.delenv("KOA_MCP_DATA_DIR", raising=False)
+        assert mcp_server.get_data_dir() == Path(mcp_server.DEFAULT_DATA_DIR)
+
+    def test_kl_env_overrides_default(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("KL_MCP_DATA_DIR", str(tmp_path))
+        monkeypatch.delenv("KOA_MCP_DATA_DIR", raising=False)
+        assert mcp_server.get_data_dir() == tmp_path
+
+    def test_koa_env_overrides_default(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("KL_MCP_DATA_DIR", raising=False)
+        monkeypatch.setenv("KOA_MCP_DATA_DIR", str(tmp_path))
+        assert mcp_server.get_data_dir() == tmp_path
+
+    def test_kl_takes_precedence_over_koa(self, monkeypatch, tmp_path):
+        kl_dir = tmp_path / "kl"
+        koa_dir = tmp_path / "koa"
+        monkeypatch.setenv("KL_MCP_DATA_DIR", str(kl_dir))
+        monkeypatch.setenv("KOA_MCP_DATA_DIR", str(koa_dir))
+        assert mcp_server.get_data_dir() == kl_dir
+
+
+# ---------------------------------------------------------------------------
+# read_json_file — robust JSON parsing
+# ---------------------------------------------------------------------------
+
+
+class TestReadJsonFile:
+    def test_reads_backend_config_dict(self, tmp_path):
+        payload = {"cost_model": "cumulative", "currency": "%"}
+        (tmp_path / "backend.json").write_text(json.dumps(payload), encoding="utf-8")
+
+        result = mcp_server.read_json_file("backend.json", data_dir=tmp_path)
+
+        assert result.ok
+        assert result.exists
+        assert result.payload == payload
+        assert result.error is None
+        assert result.mtime_utc is not None
+
+    def test_reads_histogram_like_array(self, tmp_path):
+        payload = [
+            {"stack": "openshift-monitoring", "usage": 113.001604, "date": "Feb 2026"},
+            {"stack": "registry", "usage": 5.160364, "date": "Feb 2026"},
+        ]
+        (tmp_path / "cpu_usage_period_31968000.json").write_text(json.dumps(payload), encoding="utf-8")
+
+        result = mcp_server.read_json_file("cpu_usage_period_31968000.json", data_dir=tmp_path)
+
+        assert result.ok
+        assert result.payload == payload
+        assert isinstance(result.payload, list)
+
+    def test_reads_trends_like_array(self, tmp_path):
+        payload = [
+            {"name": "openshift-nmstate", "dateUTC": "2026-02-10T11:00:00Z", "usage": 0.059653},
+            {"name": "openshift-nmstate", "dateUTC": "2026-02-10T12:00:00Z", "usage": 0.068125},
+        ]
+        (tmp_path / "cpu_usage_trends.json").write_text(json.dumps(payload), encoding="utf-8")
+
+        result = mcp_server.read_json_file("cpu_usage_trends.json", data_dir=tmp_path)
+
+        assert result.ok
+        assert result.payload == payload
+
+    def test_missing_file_returns_clean_result(self, tmp_path):
+        result = mcp_server.read_json_file("does-not-exist.json", data_dir=tmp_path)
+
+        assert not result.ok
+        assert not result.exists
+        assert result.payload is None
+        assert result.error is not None
+        assert "not found" in result.error
+        assert result.mtime_utc is None
+
+    def test_truncated_array_does_not_raise(self, tmp_path):
+        # Simulate a crash mid-dump: trailing entry truncated.
+        truncated = '[{"stack":"a","usage":1.0,"date":"Feb 2026"},{"stack":"b","usage":'
+        (tmp_path / "cpu_usage_period_31968000.json").write_text(truncated, encoding="utf-8")
+
+        result = mcp_server.read_json_file("cpu_usage_period_31968000.json", data_dir=tmp_path)
+
+        assert not result.ok
+        assert result.exists
+        assert result.payload is None
+        assert result.error is not None
+        assert "invalid JSON" in result.error
+        assert result.mtime_utc is not None
+
+    def test_empty_file_does_not_raise(self, tmp_path):
+        (tmp_path / "empty.json").write_text("", encoding="utf-8")
+
+        result = mcp_server.read_json_file("empty.json", data_dir=tmp_path)
+
+        assert not result.ok
+        assert result.exists
+        assert result.payload is None
+        assert "invalid JSON" in result.error
+
+    def test_empty_array_is_ok(self, tmp_path):
+        (tmp_path / "empty_array.json").write_text("[]", encoding="utf-8")
+
+        result = mcp_server.read_json_file("empty_array.json", data_dir=tmp_path)
+
+        # Empty list is a valid (parsed) payload; ok depends on whether we
+        # consider [] as "present data". Current contract: payload is not None,
+        # so ok is True. Callers interpret semantic emptiness themselves.
+        assert result.exists
+        assert result.error is None
+        assert result.payload == []
+        assert result.ok
+
+    def test_uses_env_when_data_dir_not_passed(self, monkeypatch, tmp_path):
+        (tmp_path / "backend.json").write_text('{"cost_model":"cumulative","currency":"%"}', encoding="utf-8")
+        monkeypatch.setenv("KL_MCP_DATA_DIR", str(tmp_path))
+        monkeypatch.delenv("KOA_MCP_DATA_DIR", raising=False)
+
+        result = mcp_server.read_json_file("backend.json")
+
+        assert result.ok
+        assert result.payload == {"cost_model": "cumulative", "currency": "%"}
+
+
+# ---------------------------------------------------------------------------
+# Filename helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHistogramFilename:
+    def test_cpu_usage_14d(self):
+        assert (
+            mcp_server.histogram_filename("cpu", "usage", mcp_server.PERIOD_14_DAYS_SEC)
+            == "cpu_usage_period_1209600.json"
+        )
+
+    def test_memory_usage_year(self):
+        assert (
+            mcp_server.histogram_filename("memory", "usage", mcp_server.PERIOD_YEAR_SEC)
+            == "memory_usage_period_31968000.json"
+        )
+
+    def test_cpu_requests_14d(self):
+        assert (
+            mcp_server.histogram_filename("cpu", "requests", mcp_server.PERIOD_14_DAYS_SEC)
+            == "cpu_requests_period_1209600.json"
+        )
+
+    def test_memory_requests_year(self):
+        assert (
+            mcp_server.histogram_filename("memory", "requests", mcp_server.PERIOD_YEAR_SEC)
+            == "memory_requests_period_31968000.json"
+        )
+
+    def test_gpu_cpu_usage_uses_mem_label_for_memory(self):
+        # GPU variant uses "mem" instead of "memory" — matches backend.py
+        assert (
+            mcp_server.histogram_filename("memory", "usage", mcp_server.PERIOD_14_DAYS_SEC, gpu=True)
+            == "gpu_mem_usage_period_1209600.json"
+        )
+        assert (
+            mcp_server.histogram_filename("cpu", "usage", mcp_server.PERIOD_14_DAYS_SEC, gpu=True)
+            == "gpu_cpu_usage_period_1209600.json"
+        )
+
+    def test_invalid_metric_raises(self):
+        with pytest.raises(ValueError):
+            mcp_server.histogram_filename("disk", "usage", mcp_server.PERIOD_14_DAYS_SEC)
+
+    def test_invalid_dimension_raises(self):
+        with pytest.raises(ValueError):
+            mcp_server.histogram_filename("cpu", "limits", mcp_server.PERIOD_14_DAYS_SEC)
+
+
+class TestTrendsFilename:
+    def test_cpu_usage_trends(self):
+        assert mcp_server.trends_filename("cpu", "usage") == "cpu_usage_trends.json"
+
+    def test_memory_usage_trends(self):
+        assert mcp_server.trends_filename("memory", "usage") == "memory_usage_trends.json"
+
+    def test_cpu_rf_trends(self):
+        assert mcp_server.trends_filename("cpu", "rf") == "cpu_rf_trends.json"
+
+    def test_memory_rf_trends(self):
+        assert mcp_server.trends_filename("memory", "rf") == "memory_rf_trends.json"
+
+    def test_gpu_cpu_usage_trends(self):
+        assert mcp_server.trends_filename("cpu", "usage", gpu=True) == "gpu_cpu_usage_trends.json"
+
+    def test_gpu_mem_usage_trends(self):
+        assert mcp_server.trends_filename("memory", "usage", gpu=True) == "gpu_mem_usage_trends.json"
+
+    def test_invalid_category_raises(self):
+        with pytest.raises(ValueError):
+            mcp_server.trends_filename("cpu", "limits")
+
+
+# ---------------------------------------------------------------------------
+# Cost model loader
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCostModel:
+    def test_cumulative(self, tmp_path):
+        (tmp_path / "backend.json").write_text('{"cost_model":"cumulative", "currency":"%"}', encoding="utf-8")
+        info, warnings = mcp_server.load_cost_model(data_dir=tmp_path)
+        assert info is not None
+        assert info.cost_model == "cumulative"
+        assert info.currency == "%"
+        assert info.unit == "percent_of_cluster_capacity"
+        assert warnings == []
+
+    def test_normalized(self, tmp_path):
+        (tmp_path / "backend.json").write_text('{"cost_model":"normalized", "currency":"%"}', encoding="utf-8")
+        info, _ = mcp_server.load_cost_model(data_dir=tmp_path)
+        assert info.unit == "relative_share_percent"
+
+    def test_costs_with_currency_symbol(self, tmp_path):
+        (tmp_path / "backend.json").write_text('{"cost_model":"costs", "currency":"$"}', encoding="utf-8")
+        info, warnings = mcp_server.load_cost_model(data_dir=tmp_path)
+        assert info.cost_model == "costs"
+        assert info.currency == "$"
+        assert info.unit == "monetary_cost"
+        assert warnings == []
+
+    def test_missing_file_returns_none_and_warning(self, tmp_path):
+        info, warnings = mcp_server.load_cost_model(data_dir=tmp_path)
+        assert info is None
+        assert warnings and "backend.json" in warnings[0]
+
+    def test_invalid_json_returns_none_and_warning(self, tmp_path):
+        (tmp_path / "backend.json").write_text("{bad", encoding="utf-8")
+        info, warnings = mcp_server.load_cost_model(data_dir=tmp_path)
+        assert info is None
+        assert warnings
+
+    def test_unknown_cost_model_still_returns_info_with_warning(self, tmp_path):
+        (tmp_path / "backend.json").write_text('{"cost_model":"future_mode", "currency":"%"}', encoding="utf-8")
+        info, warnings = mcp_server.load_cost_model(data_dir=tmp_path)
+        assert info is not None
+        assert info.unit == "unknown"
+        assert any("future_mode" in w for w in warnings)
+
+    def test_object_not_dict_returns_none(self, tmp_path):
+        (tmp_path / "backend.json").write_text("[]", encoding="utf-8")
+        info, warnings = mcp_server.load_cost_model(data_dir=tmp_path)
+        assert info is None
+        assert warnings
+
+
+# ---------------------------------------------------------------------------
+# Dataset discovery
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path, name, payload):
+    (tmp_path / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _make_daily_histogram():
+    # 3 namespaces × 4 distinct daily dates → points_per_namespace == 4.
+    return [
+        {"stack": "ns-a", "usage": 10.0, "date": "01 Feb"},
+        {"stack": "ns-a", "usage": 11.0, "date": "02 Feb"},
+        {"stack": "ns-a", "usage": 12.0, "date": "03 Feb"},
+        {"stack": "ns-a", "usage": 13.0, "date": "04 Feb"},
+        {"stack": "ns-b", "usage": 1.0, "date": "01 Feb"},
+        {"stack": "ns-b", "usage": 2.0, "date": "02 Feb"},
+        {"stack": "non-allocatable", "usage": 50.0, "date": "01 Feb"},
+    ]
+
+
+def _make_monthly_histogram():
+    return [
+        {"stack": "ns-a", "usage": 100.0, "date": "Dec 2025"},
+        {"stack": "ns-a", "usage": 110.0, "date": "Jan 2026"},
+        {"stack": "ns-a", "usage": 120.0, "date": "Feb 2026"},
+    ]
+
+
+def _make_trends_7d_hourly(start="2026-02-03T13:00:00Z", hours=7 * 24):
+    # 168 hourly points spanning 7 days for a single namespace.
+    base = datetime.fromisoformat(start.replace("Z", "+00:00"))
+    return [
+        {
+            "name": "ns-a",
+            "dateUTC": (base + timedelta(hours=i)).isoformat().replace("+00:00", "Z"),
+            "usage": 0.1 * i,
+        }
+        for i in range(hours)
+    ]
+
+
+class TestDiscoverDataset:
+    def _setup_full_dataset(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(tmp_path, "cpu_usage_period_1209600.json", _make_daily_histogram())
+        _write(tmp_path, "memory_usage_period_1209600.json", _make_daily_histogram())
+        _write(tmp_path, "cpu_usage_period_31968000.json", _make_monthly_histogram())
+        _write(tmp_path, "memory_usage_period_31968000.json", _make_monthly_histogram())
+        _write(tmp_path, "cpu_requests_period_1209600.json", _make_daily_histogram())
+        _write(tmp_path, "memory_requests_period_1209600.json", _make_daily_histogram())
+        _write(tmp_path, "cpu_usage_trends.json", _make_trends_7d_hourly())
+        _write(tmp_path, "memory_usage_trends.json", _make_trends_7d_hourly())
+        _write(tmp_path, "cpu_rf_trends.json", _make_trends_7d_hourly())
+        _write(tmp_path, "memory_rf_trends.json", _make_trends_7d_hourly())
+
+    def test_full_dataset_no_gpu(self, tmp_path):
+        self._setup_full_dataset(tmp_path)
+        info = mcp_server.discover_dataset(data_dir=tmp_path)
+
+        assert info.metrics_available == ["cpu", "memory"]
+        assert info.gpu_available is False
+        assert "usage" in info.dimensions
+        assert "requests" in info.dimensions
+
+        assert set(info.scales) == {"daily_14d", "monthly_12m"}
+        assert info.scales["daily_14d"].granularity == "daily"
+        assert info.scales["daily_14d"].points_per_namespace == 4
+        assert info.scales["monthly_12m"].granularity == "monthly"
+        assert info.scales["monthly_12m"].points_per_namespace == 3
+
+        assert info.trends is not None
+        assert info.trends.granularity == "hourly"
+        assert info.trends.depth.endswith("days")
+        assert info.trends.points_per_namespace == 168
+
+        assert info.efficiency.aggregated is True
+        assert info.efficiency.hourly_timeseries is True
+
+        assert info.cost_model is not None
+        assert info.cost_model.cost_model == "cumulative"
+        assert info.cost_model.unit == "percent_of_cluster_capacity"
+
+        assert info.billing_hourly_rate is None
+        assert info.data_freshness_utc is not None
+        assert info.warnings == []
+
+    def test_gpu_present_when_files_exist_and_non_empty(self, tmp_path):
+        self._setup_full_dataset(tmp_path)
+        _write(tmp_path, "gpu_cpu_usage_period_1209600.json", _make_daily_histogram())
+        info = mcp_server.discover_dataset(data_dir=tmp_path)
+        assert info.gpu_available is True
+
+    def test_gpu_absent_when_only_empty_gpu_files(self, tmp_path):
+        self._setup_full_dataset(tmp_path)
+        _write(tmp_path, "gpu_cpu_usage_period_1209600.json", [])
+        info = mcp_server.discover_dataset(data_dir=tmp_path)
+        assert info.gpu_available is False
+
+    def test_no_efficiency_without_requests_files(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(tmp_path, "cpu_usage_period_1209600.json", _make_daily_histogram())
+        _write(tmp_path, "cpu_usage_trends.json", _make_trends_7d_hourly())
+        info = mcp_server.discover_dataset(data_dir=tmp_path)
+
+        assert info.efficiency.aggregated is False
+        assert info.efficiency.hourly_timeseries is False
+        assert info.dimensions == ["usage"]
+
+    def test_costs_mode_warns_about_missing_billing_hourly_rate(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "costs", "currency": "$"})
+        _write(tmp_path, "cpu_usage_period_1209600.json", _make_daily_histogram())
+        info = mcp_server.discover_dataset(data_dir=tmp_path)
+
+        assert info.cost_model is not None
+        assert info.cost_model.unit == "monetary_cost"
+        assert info.billing_hourly_rate is None
+        assert any("billing_hourly_rate" in w for w in info.warnings)
+
+    def test_missing_backend_json_yields_warning_but_still_works(self, tmp_path):
+        _write(tmp_path, "cpu_usage_period_1209600.json", _make_daily_histogram())
+        info = mcp_server.discover_dataset(data_dir=tmp_path)
+
+        assert info.cost_model is None
+        assert any("backend.json" in w for w in info.warnings)
+        assert "cpu" in info.metrics_available
+
+    def test_empty_directory(self, tmp_path):
+        info = mcp_server.discover_dataset(data_dir=tmp_path)
+
+        assert info.metrics_available == []
+        assert info.dimensions == []
+        assert info.scales == {}
+        assert info.trends is None
+        assert info.efficiency.aggregated is False
+        assert info.efficiency.hourly_timeseries is False
+        assert info.cost_model is None
+        assert info.data_freshness_utc is None
+
+    def test_truncated_histogram_does_not_crash_discovery(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        # Truncated mid-file — simulates a crash during dump.
+        (tmp_path / "cpu_usage_period_1209600.json").write_text(
+            '[{"stack":"a","usage":1.0,"date":"01 Feb"},{"stack":"b","usage":',
+            encoding="utf-8",
+        )
+        info = mcp_server.discover_dataset(data_dir=tmp_path)
+        # File exists but unreadable → the metric is still reported as
+        # available (file is present), the scale just won't carry points.
+        assert "daily_14d" not in info.scales
+
+    def test_data_freshness_ignores_backend_json_mtime(self, tmp_path):
+        # Set backend.json clearly newer than data files. data_freshness must
+        # still reflect the data file mtime, not backend.json's.
+        _write(tmp_path, "cpu_usage_period_1209600.json", _make_daily_histogram())
+        data_mtime = (tmp_path / "cpu_usage_period_1209600.json").stat().st_mtime
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        # Bump backend.json's mtime forward.
+        future = data_mtime + 10_000
+        os.utime(tmp_path / "backend.json", (future, future))
+
+        info = mcp_server.discover_dataset(data_dir=tmp_path)
+        assert info.data_freshness_utc is not None
+        # Re-derive expected ISO from data file mtime — must equal info value.
+        expected = mcp_server._iso_utc(data_mtime)
+        assert info.data_freshness_utc == expected
+
+
+# ---------------------------------------------------------------------------
+# Namespace classification
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyNamespace:
+    def test_openshift_prefix_is_system(self):
+        assert mcp_server.classify_namespace("openshift-monitoring") == "system"
+        assert mcp_server.classify_namespace("openshift-nmstate") == "system"
+
+    def test_kube_prefix_is_system(self):
+        assert mcp_server.classify_namespace("kube-system") == "system"
+        assert mcp_server.classify_namespace("kube-public") == "system"
+        assert mcp_server.classify_namespace("kube-node-lease") == "system"
+
+    def test_regular_namespace_is_application(self):
+        assert mcp_server.classify_namespace("registry") == "application"
+        assert mcp_server.classify_namespace("clusters-hcp1") == "application"
+        assert mcp_server.classify_namespace("my-app-prod") == "application"
+
+    def test_special_entries(self):
+        assert mcp_server.classify_namespace("non-allocatable") == "special"
+        assert mcp_server.classify_namespace(".billing-hourly-rate") == "special"
+
+    def test_other_dot_prefixed_is_application(self):
+        # Only the known special entries are special — random dot-prefixed
+        # names are still classified by the standard rules (application here).
+        assert mcp_server.classify_namespace(".unknown-special") == "application"
+
+
+# ---------------------------------------------------------------------------
+# Tool: list_namespaces
+# ---------------------------------------------------------------------------
+
+
+class TestToolListNamespaces:
+    def _setup(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(
+            tmp_path,
+            "cpu_usage_period_1209600.json",
+            [
+                {"stack": "registry", "usage": 5.0, "date": "01 Feb"},
+                {"stack": "openshift-monitoring", "usage": 50.0, "date": "01 Feb"},
+                {"stack": "non-allocatable", "usage": 100.0, "date": "01 Feb"},
+                {"stack": "kube-system", "usage": 3.0, "date": "01 Feb"},
+            ],
+        )
+        _write(
+            tmp_path,
+            "cpu_usage_trends.json",
+            [
+                {"name": "registry", "dateUTC": "2026-02-10T11:00:00Z", "usage": 0.5},
+                {"name": "clusters-hcp1", "dateUTC": "2026-02-10T11:00:00Z", "usage": 0.7},
+            ],
+        )
+
+    def test_namespaces_classified(self, tmp_path):
+        self._setup(tmp_path)
+        result = mcp_server.tool_list_namespaces(data_dir=tmp_path)
+
+        names_by_type = {n["type"]: [] for n in result["namespaces"]}
+        for n in result["namespaces"]:
+            names_by_type[n["type"]].append(n["name"])
+
+        assert "openshift-monitoring" in names_by_type.get("system", [])
+        assert "kube-system" in names_by_type.get("system", [])
+        assert "registry" in names_by_type.get("application", [])
+        assert "clusters-hcp1" in names_by_type.get("application", [])
+        # non-allocatable must NOT appear in the namespaces list — it is a
+        # special entry, surfaced separately.
+        all_names = [n["name"] for n in result["namespaces"]]
+        assert "non-allocatable" not in all_names
+        assert ".billing-hourly-rate" not in all_names
+
+    def test_special_entries_always_listed(self, tmp_path):
+        self._setup(tmp_path)
+        result = mcp_server.tool_list_namespaces(data_dir=tmp_path)
+
+        special_names = {e["name"] for e in result["special_entries"]}
+        assert special_names == {"non-allocatable", ".billing-hourly-rate"}
+        # Each carries its role and description.
+        for entry in result["special_entries"]:
+            assert entry["role"] in ("cluster_overhead", "billing_config")
+            assert entry["description"]
+
+    def test_counts_consistent(self, tmp_path):
+        self._setup(tmp_path)
+        result = mcp_server.tool_list_namespaces(data_dir=tmp_path)
+
+        counts = result["counts"]
+        types_seen = [n["type"] for n in result["namespaces"]]
+        assert counts["application"] == types_seen.count("application")
+        assert counts["system"] == types_seen.count("system")
+        assert counts["special"] == 2  # static known list
+
+    def test_metadata_present(self, tmp_path):
+        self._setup(tmp_path)
+        result = mcp_server.tool_list_namespaces(data_dir=tmp_path)
+
+        md = result["metadata"]
+        assert md["cost_model"] == "cumulative"
+        assert md["currency"] == "%"
+        assert md["unit"] == "percent_of_cluster_capacity"
+        assert md["generated_at_utc"] is not None
+        # Tool is dataset-global → no metric/scale/data_window/source_file.
+        assert md["metric"] is None
+        assert md["scale"] is None
+        assert md["data_window"] is None
+        assert md["source_file"] is None
+
+    def test_empty_directory(self, tmp_path):
+        result = mcp_server.tool_list_namespaces(data_dir=tmp_path)
+        assert result["namespaces"] == []
+        assert result["counts"]["application"] == 0
+        assert result["counts"]["system"] == 0
+        # Special entries are static — present even without data.
+        assert result["counts"]["special"] == 2
+
+    def test_namespaces_sorted_alphabetically(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(
+            tmp_path,
+            "cpu_usage_period_1209600.json",
+            [
+                {"stack": "zeta-app", "usage": 1.0, "date": "01 Feb"},
+                {"stack": "alpha-app", "usage": 1.0, "date": "01 Feb"},
+                {"stack": "midway-app", "usage": 1.0, "date": "01 Feb"},
+            ],
+        )
+        result = mcp_server.tool_list_namespaces(data_dir=tmp_path)
+        names = [n["name"] for n in result["namespaces"]]
+        assert names == sorted(names)
+
+
+# ---------------------------------------------------------------------------
+# Tool: describe_dataset
+# ---------------------------------------------------------------------------
+
+
+class TestToolDescribeDataset:
+    def test_full_response_shape(self, tmp_path):
+        # Re-use the full-dataset fixture from earlier.
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(tmp_path, "cpu_usage_period_1209600.json", _make_daily_histogram())
+        _write(tmp_path, "memory_usage_period_1209600.json", _make_daily_histogram())
+        _write(tmp_path, "cpu_usage_period_31968000.json", _make_monthly_histogram())
+        _write(tmp_path, "cpu_requests_period_1209600.json", _make_daily_histogram())
+        _write(tmp_path, "cpu_usage_trends.json", _make_trends_7d_hourly())
+        _write(tmp_path, "cpu_rf_trends.json", _make_trends_7d_hourly())
+
+        result = mcp_server.tool_describe_dataset(data_dir=tmp_path)
+
+        # Top-level shape per spec §4.1
+        assert "metrics_available" in result
+        assert "gpu_available" in result
+        assert "scales" in result
+        assert "trends" in result
+        assert "dimensions" in result
+        assert "efficiency" in result
+        assert "cost_model" in result
+        assert "currency" in result
+        assert "billing_hourly_rate" in result
+        assert "data_freshness_utc" in result
+        assert "metadata" in result
+
+        # cost_model & currency flat (not nested) at top level.
+        assert result["cost_model"] == "cumulative"
+        assert result["currency"] == "%"
+
+        # Efficiency block has the expected sub-fields.
+        assert set(result["efficiency"].keys()) == {"aggregated", "hourly_timeseries"}
+
+        # Trends block has expected sub-fields.
+        assert set(result["trends"].keys()) == {"granularity", "depth", "points_per_namespace"}
+
+        # Each scale entry is a flat dict (no nested dataclass).
+        for scale_data in result["scales"].values():
+            assert set(scale_data.keys()) == {"granularity", "depth", "points_per_namespace"}
+
+    def test_gpu_available_flag(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(tmp_path, "cpu_usage_period_1209600.json", _make_daily_histogram())
+        _write(tmp_path, "gpu_cpu_usage_period_1209600.json", _make_daily_histogram())
+
+        result = mcp_server.tool_describe_dataset(data_dir=tmp_path)
+        assert result["gpu_available"] is True
+
+    def test_billing_hourly_rate_null_in_cumulative(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(tmp_path, "cpu_usage_period_1209600.json", _make_daily_histogram())
+
+        result = mcp_server.tool_describe_dataset(data_dir=tmp_path)
+        assert result["billing_hourly_rate"] is None
+
+    def test_metadata_carries_unit(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "normalized", "currency": "%"})
+        _write(tmp_path, "cpu_usage_period_1209600.json", _make_daily_histogram())
+
+        result = mcp_server.tool_describe_dataset(data_dir=tmp_path)
+        assert result["metadata"]["unit"] == "relative_share_percent"
+
+
+# ---------------------------------------------------------------------------
+# build_metadata — freshness warning, optional fields
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMetadata:
+    def _cost_model(self):
+        return mcp_server.CostModelInfo(
+            cost_model="cumulative",
+            currency="%",
+            unit="percent_of_cluster_capacity",
+        )
+
+    def test_includes_all_fields(self):
+        md = mcp_server.build_metadata(
+            cost_model=self._cost_model(),
+            metric="cpu",
+            scale="daily_14d",
+            source_file="cpu_usage_period_1209600.json",
+            data_window={"start": "01 Feb", "end": "04 Feb", "points": 4},
+        )
+        assert md["metric"] == "cpu"
+        assert md["scale"] == "daily_14d"
+        assert md["source_file"] == "cpu_usage_period_1209600.json"
+        assert md["data_window"]["points"] == 4
+        assert md["warnings"] == []
+
+    def test_no_cost_model_yields_null_fields(self):
+        md = mcp_server.build_metadata(cost_model=None)
+        assert md["cost_model"] is None
+        assert md["currency"] is None
+        assert md["unit"] is None
+
+    def test_freshness_warning_when_data_stale(self):
+        from datetime import datetime
+
+        old = datetime.now(tz=UTC).timestamp() - 3600  # 1 hour ago
+        md = mcp_server.build_metadata(
+            cost_model=self._cost_model(),
+            generated_at_mtime=old,
+        )
+        assert any("stale data" in w for w in md["warnings"])
+        assert md["generated_at_utc"] is not None
+
+    def test_no_freshness_warning_when_recent(self):
+        from datetime import datetime
+
+        recent = datetime.now(tz=UTC).timestamp() - 60  # 1 minute ago
+        md = mcp_server.build_metadata(
+            cost_model=self._cost_model(),
+            generated_at_mtime=recent,
+        )
+        assert not any("stale data" in w for w in md["warnings"])
+
+    def test_preserves_caller_warnings(self):
+        md = mcp_server.build_metadata(
+            cost_model=self._cost_model(),
+            warnings=["custom warning A", "custom warning B"],
+        )
+        assert "custom warning A" in md["warnings"]
+        assert "custom warning B" in md["warnings"]
+
+    def test_unit_override(self):
+        md = mcp_server.build_metadata(
+            cost_model=self._cost_model(),
+            unit_override="efficiency_ratio",
+        )
+        assert md["unit"] == "efficiency_ratio"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures for Consolidations tools (§4.2)
+# ---------------------------------------------------------------------------
+
+
+def _make_consolidation_dataset():
+    """Two-date dataset with system, application, and non-allocatable entries.
+
+    Date "01 Feb":
+        registry=10, alpha=5, openshift-monitoring=40, kube-system=3,
+        non-allocatable=100
+    Date "02 Feb":
+        registry=20, alpha=30, openshift-monitoring=50, kube-system=4,
+        non-allocatable=90
+    """
+    return [
+        # 01 Feb
+        {"stack": "registry", "usage": 10.0, "date": "01 Feb"},
+        {"stack": "alpha", "usage": 5.0, "date": "01 Feb"},
+        {"stack": "openshift-monitoring", "usage": 40.0, "date": "01 Feb"},
+        {"stack": "kube-system", "usage": 3.0, "date": "01 Feb"},
+        {"stack": "non-allocatable", "usage": 100.0, "date": "01 Feb"},
+        # 02 Feb
+        {"stack": "registry", "usage": 20.0, "date": "02 Feb"},
+        {"stack": "alpha", "usage": 30.0, "date": "02 Feb"},
+        {"stack": "openshift-monitoring", "usage": 50.0, "date": "02 Feb"},
+        {"stack": "kube-system", "usage": 4.0, "date": "02 Feb"},
+        {"stack": "non-allocatable", "usage": 90.0, "date": "02 Feb"},
+    ]
+
+
+def _setup_consolidation_fixture(tmp_path, cost_model="cumulative", currency="%"):
+    _write(tmp_path, "backend.json", {"cost_model": cost_model, "currency": currency})
+    _write(tmp_path, "cpu_usage_period_1209600.json", _make_consolidation_dataset())
+    _write(tmp_path, "cpu_usage_period_31968000.json", _make_consolidation_dataset())
+
+
+# ---------------------------------------------------------------------------
+# Tool: get_usage
+# ---------------------------------------------------------------------------
+
+
+class TestToolGetUsage:
+    def test_default_excludes_special(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_usage(
+            metric="cpu",
+            scale="daily_14d",
+            data_dir=tmp_path,
+        )
+        ns_seen = {p["namespace"] for p in result["series"]}
+        assert "non-allocatable" not in ns_seen
+        assert "registry" in ns_seen
+        assert "openshift-monitoring" in ns_seen  # system kept by get_usage
+
+    def test_exclude_special_false_keeps_non_allocatable(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_usage(
+            metric="cpu",
+            scale="daily_14d",
+            exclude_special=False,
+            data_dir=tmp_path,
+        )
+        ns_seen = {p["namespace"] for p in result["series"]}
+        assert "non-allocatable" in ns_seen
+
+    def test_filter_by_namespace(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_usage(
+            metric="cpu",
+            scale="daily_14d",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        assert all(p["namespace"] == "registry" for p in result["series"])
+        assert len(result["series"]) == 2  # two dates
+
+    def test_series_points_have_required_fields(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_usage(
+            metric="cpu",
+            scale="daily_14d",
+            data_dir=tmp_path,
+        )
+        for p in result["series"]:
+            assert set(p.keys()) == {"namespace", "date", "value"}
+            assert isinstance(p["value"], float)
+
+    def test_data_window_in_metadata(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_usage(
+            metric="cpu",
+            scale="daily_14d",
+            data_dir=tmp_path,
+        )
+        window = result["metadata"]["data_window"]
+        assert window["granularity"] == "daily"
+        assert window["start"] == "01 Feb"
+        assert window["end"] == "02 Feb"
+        assert window["points"] == 2
+        assert window["timezone"] == "UTC"
+        assert result["metadata"]["source_file"] == "cpu_usage_period_1209600.json"
+
+    def test_invalid_metric_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            mcp_server.tool_get_usage(metric="disk", scale="daily_14d", data_dir=tmp_path)
+
+    def test_invalid_scale_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            mcp_server.tool_get_usage(metric="cpu", scale="hourly", data_dir=tmp_path)
+
+    def test_missing_file_yields_empty_series_and_warning(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        result = mcp_server.tool_get_usage(
+            metric="cpu",
+            scale="daily_14d",
+            data_dir=tmp_path,
+        )
+        assert result["series"] == []
+        assert result["metadata"]["warnings"]
+
+
+# ---------------------------------------------------------------------------
+# Tool: get_top_consumers
+# ---------------------------------------------------------------------------
+
+
+class TestToolGetTopConsumers:
+    def test_excludes_system_by_default(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_top_consumers(
+            metric="cpu",
+            scale="daily_14d",
+            data_dir=tmp_path,
+        )
+        names = {r["namespace"] for r in result["ranking"]}
+        assert "openshift-monitoring" not in names
+        assert "kube-system" not in names
+        assert "non-allocatable" not in names  # always excluded
+        assert "registry" in names
+        assert "alpha" in names
+
+    def test_includes_system_when_flag_off(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_top_consumers(
+            metric="cpu",
+            scale="daily_14d",
+            exclude_system=False,
+            data_dir=tmp_path,
+        )
+        names = {r["namespace"] for r in result["ranking"]}
+        assert "openshift-monitoring" in names
+        assert "kube-system" in names
+        # non-allocatable still excluded — rule is invariant
+        assert "non-allocatable" not in names
+
+    def test_uses_last_date_by_default(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_top_consumers(
+            metric="cpu",
+            scale="daily_14d",
+            data_dir=tmp_path,
+        )
+        assert result["date"] == "02 Feb"
+
+    def test_explicit_date_filter(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_top_consumers(
+            metric="cpu",
+            scale="daily_14d",
+            date="01 Feb",
+            data_dir=tmp_path,
+        )
+        assert result["date"] == "01 Feb"
+        # On 01 Feb, registry=10 > alpha=5
+        assert result["ranking"][0]["namespace"] == "registry"
+        assert result["ranking"][1]["namespace"] == "alpha"
+
+    def test_share_pct_sums_to_100_in_ranking(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_top_consumers(
+            metric="cpu",
+            scale="daily_14d",
+            date="01 Feb",
+            data_dir=tmp_path,
+        )
+        # Only application namespaces on 01 Feb (defaults): registry=10, alpha=5
+        # total=15 → registry=66.67%, alpha=33.33%
+        shares = [r["share_pct"] for r in result["ranking"]]
+        assert abs(sum(shares) - 100.0) < 0.1
+
+    def test_ranks_are_1_indexed_and_descending(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_top_consumers(
+            metric="cpu",
+            scale="daily_14d",
+            data_dir=tmp_path,
+        )
+        ranks = [r["rank"] for r in result["ranking"]]
+        assert ranks == list(range(1, len(ranks) + 1))
+        values = [r["value"] for r in result["ranking"]]
+        assert values == sorted(values, reverse=True)
+
+    def test_limit_caps_results(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_top_consumers(
+            metric="cpu",
+            scale="daily_14d",
+            limit=1,
+            data_dir=tmp_path,
+        )
+        assert len(result["ranking"]) == 1
+
+    def test_unknown_date_warns_but_returns_empty(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_top_consumers(
+            metric="cpu",
+            scale="daily_14d",
+            date="99 Dec",
+            data_dir=tmp_path,
+        )
+        assert result["ranking"] == []
+        assert any("99 Dec" in w for w in result["metadata"]["warnings"])
+
+    def test_invalid_limit_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            mcp_server.tool_get_top_consumers(
+                metric="cpu",
+                scale="daily_14d",
+                limit=0,
+                data_dir=tmp_path,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tool: get_namespace_breakdown
+# ---------------------------------------------------------------------------
+
+
+class TestToolGetNamespaceBreakdown:
+    def test_excludes_system_by_default(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_namespace_breakdown(
+            metric="cpu",
+            scale="daily_14d",
+            data_dir=tmp_path,
+        )
+        names = {b["namespace"] for b in result["breakdown"]}
+        assert "openshift-monitoring" not in names
+        assert "kube-system" not in names
+        assert "non-allocatable" not in names  # NEVER in breakdown
+        assert "registry" in names
+        assert "alpha" in names
+
+    def test_cluster_overhead_present_when_non_allocatable_exists(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_namespace_breakdown(
+            metric="cpu",
+            scale="daily_14d",
+            date="02 Feb",
+            data_dir=tmp_path,
+        )
+        # On 02 Feb: registry=20, alpha=30 (apps), non-allocatable=90
+        # total cluster = 50 + 90 = 140
+        # non_allocatable_share = 90/140 ≈ 64.29%
+        # allocatable_share = 50/140 ≈ 35.71%
+        co = result["cluster_overhead"]
+        assert co is not None
+        assert co["non_allocatable_value"] == 90.0
+        assert abs(co["non_allocatable_share_pct"] - 64.29) < 0.1
+        assert abs(co["allocatable_share_pct"] - 35.71) < 0.1
+        # The two shares must sum to ~100% per spec.
+        assert abs(co["non_allocatable_share_pct"] + co["allocatable_share_pct"] - 100.0) < 0.1
+
+    def test_cluster_overhead_omitted_when_non_allocatable_missing(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(
+            tmp_path,
+            "cpu_usage_period_1209600.json",
+            [
+                {"stack": "registry", "usage": 10.0, "date": "01 Feb"},
+                {"stack": "alpha", "usage": 5.0, "date": "01 Feb"},
+            ],
+        )
+        result = mcp_server.tool_get_namespace_breakdown(
+            metric="cpu",
+            scale="daily_14d",
+            data_dir=tmp_path,
+        )
+        assert result["cluster_overhead"] is None
+        assert any("non-allocatable" in w for w in result["metadata"]["warnings"])
+
+    def test_concentration_metrics(self, tmp_path):
+        # Build a clear concentration: 5 namespaces, one dominating.
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(
+            tmp_path,
+            "cpu_usage_period_1209600.json",
+            [
+                {"stack": "ns-1", "usage": 60.0, "date": "01 Feb"},  # dominant
+                {"stack": "ns-2", "usage": 20.0, "date": "01 Feb"},
+                {"stack": "ns-3", "usage": 10.0, "date": "01 Feb"},
+                {"stack": "ns-4", "usage": 5.0, "date": "01 Feb"},
+                {"stack": "ns-5", "usage": 5.0, "date": "01 Feb"},
+            ],
+        )
+        result = mcp_server.tool_get_namespace_breakdown(
+            metric="cpu",
+            scale="daily_14d",
+            data_dir=tmp_path,
+        )
+        c = result["concentration"]
+        # top_3 = 60+20+10 = 90; total = 100 → 90%
+        assert c["top_3_share_pct"] == 90.0
+        # top_10 covers all 5 here → 100%
+        assert c["top_10_share_pct"] == 100.0
+        assert c["total_namespaces"] == 5
+
+    def test_share_pct_in_breakdown_sums_to_100(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_namespace_breakdown(
+            metric="cpu",
+            scale="daily_14d",
+            date="02 Feb",
+            data_dir=tmp_path,
+        )
+        shares = [b["share_pct"] for b in result["breakdown"]]
+        assert abs(sum(shares) - 100.0) < 0.1
+
+    def test_breakdown_sorted_by_value_desc(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_namespace_breakdown(
+            metric="cpu",
+            scale="daily_14d",
+            date="02 Feb",
+            data_dir=tmp_path,
+        )
+        values = [b["value"] for b in result["breakdown"]]
+        assert values == sorted(values, reverse=True)
+
+    def test_data_window_single_date(self, tmp_path):
+        _setup_consolidation_fixture(tmp_path)
+        result = mcp_server.tool_get_namespace_breakdown(
+            metric="cpu",
+            scale="daily_14d",
+            date="02 Feb",
+            data_dir=tmp_path,
+        )
+        window = result["metadata"]["data_window"]
+        assert window["start"] == "02 Feb"
+        assert window["end"] == "02 Feb"
+        assert window["points"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Tool: get_efficiency (§4.3)
+# ---------------------------------------------------------------------------
+
+
+def _setup_efficiency_fixture(tmp_path):
+    """Two namespaces × two dates × usage + requests, both CPU and memory.
+
+    namespace "registry":
+        cpu:    usage = 10+15 = 25,  requests = 40+50 = 90    → ratio 0.278 → over_provisioned
+        memory: usage = 80+100 = 180, requests = 100+110 = 210 → ratio 0.857 → balanced
+
+    namespace "hot-app":
+        cpu:    usage = 60+70 = 130, requests = 50+60 = 110    → ratio 1.18  → under_provisioned
+        memory: usage = 30+40 = 70,  requests = 100+100 = 200  → ratio 0.35  → over_provisioned
+    """
+    _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+
+    _write(
+        tmp_path,
+        "cpu_usage_period_1209600.json",
+        [
+            {"stack": "registry", "usage": 10.0, "date": "01 Feb"},
+            {"stack": "registry", "usage": 15.0, "date": "02 Feb"},
+            {"stack": "hot-app", "usage": 60.0, "date": "01 Feb"},
+            {"stack": "hot-app", "usage": 70.0, "date": "02 Feb"},
+            # Special entries must be ignored even if present.
+            {"stack": "non-allocatable", "usage": 200.0, "date": "01 Feb"},
+        ],
+    )
+    _write(
+        tmp_path,
+        "cpu_requests_period_1209600.json",
+        [
+            {"stack": "registry", "usage": 40.0, "date": "01 Feb"},
+            {"stack": "registry", "usage": 50.0, "date": "02 Feb"},
+            {"stack": "hot-app", "usage": 50.0, "date": "01 Feb"},
+            {"stack": "hot-app", "usage": 60.0, "date": "02 Feb"},
+            {"stack": "non-allocatable", "usage": 0.0, "date": "01 Feb"},
+        ],
+    )
+    _write(
+        tmp_path,
+        "memory_usage_period_1209600.json",
+        [
+            {"stack": "registry", "usage": 80.0, "date": "01 Feb"},
+            {"stack": "registry", "usage": 100.0, "date": "02 Feb"},
+            {"stack": "hot-app", "usage": 30.0, "date": "01 Feb"},
+            {"stack": "hot-app", "usage": 40.0, "date": "02 Feb"},
+        ],
+    )
+    _write(
+        tmp_path,
+        "memory_requests_period_1209600.json",
+        [
+            {"stack": "registry", "usage": 100.0, "date": "01 Feb"},
+            {"stack": "registry", "usage": 110.0, "date": "02 Feb"},
+            {"stack": "hot-app", "usage": 100.0, "date": "01 Feb"},
+            {"stack": "hot-app", "usage": 100.0, "date": "02 Feb"},
+        ],
+    )
+
+
+class TestToolGetEfficiency:
+    def test_returns_both_metrics_by_default(self, tmp_path):
+        _setup_efficiency_fixture(tmp_path)
+        result = mcp_server.tool_get_efficiency(scale="daily_14d", data_dir=tmp_path)
+
+        metrics_seen = {e["metric"] for e in result["efficiency"]}
+        assert metrics_seen == {"cpu", "memory"}
+
+    def test_filter_by_metric(self, tmp_path):
+        _setup_efficiency_fixture(tmp_path)
+        result = mcp_server.tool_get_efficiency(
+            scale="daily_14d",
+            metric="cpu",
+            data_dir=tmp_path,
+        )
+        metrics_seen = {e["metric"] for e in result["efficiency"]}
+        assert metrics_seen == {"cpu"}
+
+    def test_filter_by_namespace(self, tmp_path):
+        _setup_efficiency_fixture(tmp_path)
+        result = mcp_server.tool_get_efficiency(
+            scale="daily_14d",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        ns_seen = {e["namespace"] for e in result["efficiency"]}
+        assert ns_seen == {"registry"}
+
+    def test_ratios_computed_correctly(self, tmp_path):
+        _setup_efficiency_fixture(tmp_path)
+        result = mcp_server.tool_get_efficiency(scale="daily_14d", data_dir=tmp_path)
+
+        by_key = {(e["namespace"], e["metric"]): e for e in result["efficiency"]}
+
+        # registry cpu: usage 25 / requests 90 ≈ 0.2778
+        reg_cpu = by_key[("registry", "cpu")]
+        assert reg_cpu["usage"] == 25.0
+        assert reg_cpu["requests"] == 90.0
+        assert abs(reg_cpu["efficiency_ratio"] - 25.0 / 90.0) < 1e-6
+        assert reg_cpu["classification"] == "over_provisioned"
+
+        # registry memory: 180 / 210 ≈ 0.857 → balanced
+        reg_mem = by_key[("registry", "memory")]
+        assert reg_mem["classification"] == "balanced"
+
+        # hot-app cpu: 130 / 110 ≈ 1.18 → under_provisioned
+        hot_cpu = by_key[("hot-app", "cpu")]
+        assert hot_cpu["classification"] == "under_provisioned"
+
+        # hot-app memory: 70 / 200 = 0.35 → over_provisioned
+        hot_mem = by_key[("hot-app", "memory")]
+        assert hot_mem["classification"] == "over_provisioned"
+
+    def test_special_entries_excluded(self, tmp_path):
+        _setup_efficiency_fixture(tmp_path)
+        result = mcp_server.tool_get_efficiency(scale="daily_14d", data_dir=tmp_path)
+        ns_seen = {e["namespace"] for e in result["efficiency"]}
+        assert "non-allocatable" not in ns_seen
+        assert ".billing-hourly-rate" not in ns_seen
+
+    def test_requests_below_threshold_yields_null_ratio(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(
+            tmp_path,
+            "cpu_usage_period_1209600.json",
+            [
+                {"stack": "weird-ns", "usage": 10.0, "date": "01 Feb"},
+            ],
+        )
+        # requests aggregate sub-threshold (simulates very high rf)
+        _write(
+            tmp_path,
+            "cpu_requests_period_1209600.json",
+            [
+                {"stack": "weird-ns", "usage": 1e-9, "date": "01 Feb"},
+            ],
+        )
+        result = mcp_server.tool_get_efficiency(
+            scale="daily_14d",
+            metric="cpu",
+            data_dir=tmp_path,
+        )
+        assert len(result["efficiency"]) == 1
+        entry = result["efficiency"][0]
+        assert entry["efficiency_ratio"] is None
+        assert entry["classification"] is None
+        assert any("threshold" in w for w in result["metadata"]["warnings"])
+
+    def test_requests_exactly_zero_also_yields_null(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(
+            tmp_path,
+            "cpu_usage_period_1209600.json",
+            [
+                {"stack": "ns", "usage": 5.0, "date": "01 Feb"},
+            ],
+        )
+        _write(
+            tmp_path,
+            "cpu_requests_period_1209600.json",
+            [
+                {"stack": "ns", "usage": 0.0, "date": "01 Feb"},
+            ],
+        )
+        result = mcp_server.tool_get_efficiency(
+            scale="daily_14d",
+            metric="cpu",
+            data_dir=tmp_path,
+        )
+        assert result["efficiency"][0]["efficiency_ratio"] is None
+
+    def test_metadata_unit_is_efficiency_ratio(self, tmp_path):
+        _setup_efficiency_fixture(tmp_path)
+        result = mcp_server.tool_get_efficiency(scale="daily_14d", data_dir=tmp_path)
+        # Headline number in the body is the ratio — metadata.unit must
+        # reflect that (not the cost_model unit), per spec §4.3/§4.6 spirit.
+        assert result["metadata"]["unit"] == "efficiency_ratio"
+        # cost_model and currency are still present for context.
+        assert result["metadata"]["cost_model"] == "cumulative"
+        assert result["metadata"]["currency"] == "%"
+
+    def test_sorted_by_namespace_then_metric(self, tmp_path):
+        _setup_efficiency_fixture(tmp_path)
+        result = mcp_server.tool_get_efficiency(scale="daily_14d", data_dir=tmp_path)
+        pairs = [(e["namespace"], e["metric"]) for e in result["efficiency"]]
+        assert pairs == sorted(pairs)
+
+    def test_missing_requests_file_warns_and_skips_metric(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(
+            tmp_path,
+            "cpu_usage_period_1209600.json",
+            [
+                {"stack": "ns", "usage": 10.0, "date": "01 Feb"},
+            ],
+        )
+        # No cpu_requests file → cpu metric is skipped with a warning.
+        result = mcp_server.tool_get_efficiency(
+            scale="daily_14d",
+            metric="cpu",
+            data_dir=tmp_path,
+        )
+        assert result["efficiency"] == []
+        assert any("requests" in w.lower() for w in result["metadata"]["warnings"])
+
+    def test_unknown_namespace_warns(self, tmp_path):
+        _setup_efficiency_fixture(tmp_path)
+        result = mcp_server.tool_get_efficiency(
+            scale="daily_14d",
+            namespace="ghost-ns",
+            data_dir=tmp_path,
+        )
+        assert result["efficiency"] == []
+        assert any("ghost-ns" in w for w in result["metadata"]["warnings"])
+
+    def test_data_window_reflects_actual_dates(self, tmp_path):
+        _setup_efficiency_fixture(tmp_path)
+        result = mcp_server.tool_get_efficiency(scale="daily_14d", data_dir=tmp_path)
+        window = result["metadata"]["data_window"]
+        assert window is not None
+        assert window["start"] == "01 Feb"
+        assert window["end"] == "02 Feb"
+        assert window["points"] == 2
+
+    def test_source_file_lists_both_files(self, tmp_path):
+        _setup_efficiency_fixture(tmp_path)
+        result = mcp_server.tool_get_efficiency(
+            scale="daily_14d",
+            metric="cpu",
+            data_dir=tmp_path,
+        )
+        sf = result["metadata"]["source_file"]
+        assert "cpu_usage_period_1209600.json" in sf
+        assert "cpu_requests_period_1209600.json" in sf
+
+    def test_invalid_scale_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            mcp_server.tool_get_efficiency(scale="hourly", data_dir=tmp_path)
+
+    def test_invalid_metric_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            mcp_server.tool_get_efficiency(
+                scale="daily_14d",
+                metric="disk",
+                data_dir=tmp_path,
+            )
+
+
+class TestClassifyEfficiency:
+    def test_threshold_boundaries(self):
+        assert mcp_server._classify_efficiency(0.0) == "over_provisioned"
+        assert mcp_server._classify_efficiency(0.49) == "over_provisioned"
+        assert mcp_server._classify_efficiency(0.5) == "balanced"
+        assert mcp_server._classify_efficiency(0.85) == "balanced"
+        assert mcp_server._classify_efficiency(1.0) == "balanced"
+        assert mcp_server._classify_efficiency(1.01) == "under_provisioned"
+        assert mcp_server._classify_efficiency(5.0) == "under_provisioned"
+
+
+# ---------------------------------------------------------------------------
+# Trends tools — fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_trends_for_namespace(name, start_hour="2026-02-03T13:00:00Z", count=10, base=1.0):
+    base_dt = datetime.fromisoformat(start_hour.replace("Z", "+00:00"))
+    return [
+        {
+            "name": name,
+            "dateUTC": (base_dt + timedelta(hours=i)).isoformat().replace("+00:00", "Z"),
+            "usage": _round_value(base + 0.1 * i),
+        }
+        for i in range(count)
+    ]
+
+
+def _round_value(v):
+    return round(float(v), 6)
+
+
+# ---------------------------------------------------------------------------
+# Tool: get_timeseries (§4.4)
+# ---------------------------------------------------------------------------
+
+
+class TestToolGetTimeseries:
+    def _setup(self, tmp_path, name="registry", count=10):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(tmp_path, "cpu_usage_trends.json", _make_trends_for_namespace(name, count=count))
+
+    def test_returns_series_and_stats(self, tmp_path):
+        self._setup(tmp_path, count=5)
+        result = mcp_server.tool_get_timeseries(
+            metric="cpu",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        assert len(result["series"]) == 5
+        assert result["stats"]["points"] == 5
+        # Series usage values are 1.0, 1.1, 1.2, 1.3, 1.4
+        assert result["stats"]["min"] == 1.0
+        assert result["stats"]["max"] == 1.4
+        assert abs(result["stats"]["mean"] - 1.2) < 1e-6
+
+    def test_window_bounds_match_series(self, tmp_path):
+        self._setup(tmp_path, count=3)
+        result = mcp_server.tool_get_timeseries(
+            metric="cpu",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        assert result["stats"]["window_start_utc"] == result["series"][0]["dateUTC"]
+        assert result["stats"]["window_end_utc"] == result["series"][-1]["dateUTC"]
+
+    def test_filters_only_requested_namespace(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(
+            tmp_path,
+            "cpu_usage_trends.json",
+            _make_trends_for_namespace("registry", count=3) + _make_trends_for_namespace("other-ns", count=5),
+        )
+        result = mcp_server.tool_get_timeseries(
+            metric="cpu",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        assert all(p["dateUTC"] for p in result["series"])
+        assert len(result["series"]) == 3
+
+    def test_missing_namespace_returns_empty_with_warning(self, tmp_path):
+        self._setup(tmp_path)
+        result = mcp_server.tool_get_timeseries(
+            metric="cpu",
+            namespace="ghost-ns",
+            data_dir=tmp_path,
+        )
+        assert result["series"] == []
+        assert result["stats"]["points"] == 0
+        assert any("ghost-ns" in w for w in result["metadata"]["warnings"])
+
+    def test_missing_file_returns_empty_with_warning(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        result = mcp_server.tool_get_timeseries(
+            metric="cpu",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        assert result["series"] == []
+        assert result["stats"]["points"] == 0
+        assert any("cpu_usage_trends.json" in w for w in result["metadata"]["warnings"])
+
+    def test_metadata_data_window(self, tmp_path):
+        self._setup(tmp_path, count=4)
+        result = mcp_server.tool_get_timeseries(
+            metric="cpu",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        window = result["metadata"]["data_window"]
+        assert window is not None
+        assert window["granularity"] == "hourly"
+        assert window["points"] == 4
+        assert window["timezone"] == "UTC"
+        assert result["metadata"]["source_file"] == "cpu_usage_trends.json"
+
+    def test_invalid_metric_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            mcp_server.tool_get_timeseries(metric="disk", namespace="x", data_dir=tmp_path)
+
+    def test_empty_namespace_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            mcp_server.tool_get_timeseries(metric="cpu", namespace="", data_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Tool: get_efficiency_timeseries (§4.4)
+# ---------------------------------------------------------------------------
+
+
+class TestToolGetEfficiencyTimeseries:
+    def test_reads_rf_trends_file(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        # Same shape as usage trends — value field is "usage" but semantic
+        # is efficiency ratio (spec §2.2)
+        rf_entries = [
+            {"name": "registry", "dateUTC": "2026-02-10T11:00:00Z", "usage": 0.3},
+            {"name": "registry", "dateUTC": "2026-02-10T12:00:00Z", "usage": 0.4},
+            {"name": "registry", "dateUTC": "2026-02-10T13:00:00Z", "usage": 1.2},  # > 1: under-provisioned hour
+        ]
+        _write(tmp_path, "cpu_rf_trends.json", rf_entries)
+
+        result = mcp_server.tool_get_efficiency_timeseries(
+            metric="cpu",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        assert len(result["series"]) == 3
+        assert result["stats"]["max"] == 1.2  # ratio > 1 preserved (spec §4.4)
+        assert result["metadata"]["unit"] == "efficiency_ratio"
+
+    def test_unit_override_propagates_when_empty(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "costs", "currency": "$"})
+        # No rf file at all
+        result = mcp_server.tool_get_efficiency_timeseries(
+            metric="cpu",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        # Even in error/empty case, unit must say efficiency_ratio
+        assert result["metadata"]["unit"] == "efficiency_ratio"
+
+    def test_invalid_metric_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            mcp_server.tool_get_efficiency_timeseries(
+                metric="disk",
+                namespace="x",
+                data_dir=tmp_path,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tool: compare_periods (§4.4)
+# ---------------------------------------------------------------------------
+
+
+class TestToolComparePeriods:
+    def _setup(self, tmp_path, monthly_values=None):
+        if monthly_values is None:
+            monthly_values = [10.0, 12.0, 14.0, 16.0]  # growing
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(
+            tmp_path,
+            "cpu_usage_period_1209600.json",
+            [
+                {"stack": "registry", "usage": 5.0, "date": "01 Feb"},
+                {"stack": "registry", "usage": 7.0, "date": "02 Feb"},
+                {"stack": "registry", "usage": 3.0, "date": "03 Feb"},
+                {"stack": "other", "usage": 999.0, "date": "01 Feb"},
+            ],
+        )
+        months = ["Nov 2025", "Dec 2025", "Jan 2026", "Feb 2026"]
+        _write(
+            tmp_path,
+            "cpu_usage_period_31968000.json",
+            [{"stack": "registry", "usage": v, "date": m} for v, m in zip(monthly_values, months, strict=True)]
+            + [{"stack": "other", "usage": 50.0, "date": "Feb 2026"}],
+        )
+
+    def test_returns_both_blocks(self, tmp_path):
+        self._setup(tmp_path)
+        result = mcp_server.tool_compare_periods(
+            metric="cpu",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        assert "daily_14d" in result
+        assert "monthly_12m" in result
+        assert result["daily_14d"]["aggregate"] == 15.0  # 5 + 7 + 3
+        assert result["daily_14d"]["points"] == 3
+        assert result["daily_14d"]["window_start"] == "01 Feb"
+        assert result["daily_14d"]["window_end"] == "03 Feb"
+
+    def test_monthly_series_preserves_order(self, tmp_path):
+        self._setup(tmp_path)
+        result = mcp_server.tool_compare_periods(
+            metric="cpu",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        dates = [p["date"] for p in result["monthly_12m"]["series"]]
+        assert dates == ["Nov 2025", "Dec 2025", "Jan 2026", "Feb 2026"]
+
+    def test_trend_growing(self, tmp_path):
+        self._setup(tmp_path, monthly_values=[10.0, 12.0, 14.0, 16.0])
+        result = mcp_server.tool_compare_periods(
+            metric="cpu",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        assert result["monthly_12m"]["trend_direction"] == "growing"
+
+    def test_trend_decreasing(self, tmp_path):
+        self._setup(tmp_path, monthly_values=[100.0, 90.0, 70.0, 60.0])
+        result = mcp_server.tool_compare_periods(
+            metric="cpu",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        assert result["monthly_12m"]["trend_direction"] == "decreasing"
+
+    def test_trend_stable(self, tmp_path):
+        self._setup(tmp_path, monthly_values=[100.0, 102.0, 101.0, 99.0])
+        result = mcp_server.tool_compare_periods(
+            metric="cpu",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        assert result["monthly_12m"]["trend_direction"] == "stable"
+
+    def test_trend_insufficient_data(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(
+            tmp_path,
+            "cpu_usage_period_1209600.json",
+            [
+                {"stack": "registry", "usage": 5.0, "date": "01 Feb"},
+            ],
+        )
+        _write(
+            tmp_path,
+            "cpu_usage_period_31968000.json",
+            [
+                {"stack": "registry", "usage": 10.0, "date": "Feb 2026"},
+            ],
+        )
+        result = mcp_server.tool_compare_periods(
+            metric="cpu",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        assert result["monthly_12m"]["trend_direction"] == "insufficient_data"
+
+    def test_missing_daily_file_still_returns_monthly(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(
+            tmp_path,
+            "cpu_usage_period_31968000.json",
+            [
+                {"stack": "registry", "usage": v, "date": d}
+                for v, d in [(10.0, "Nov 2025"), (12.0, "Dec 2025"), (14.0, "Jan 2026"), (16.0, "Feb 2026")]
+            ],
+        )
+        result = mcp_server.tool_compare_periods(
+            metric="cpu",
+            namespace="registry",
+            data_dir=tmp_path,
+        )
+        assert result["daily_14d"] is None
+        assert result["monthly_12m"] is not None
+        assert result["monthly_12m"]["trend_direction"] == "growing"
+        assert any("period_1209600" in w for w in result["metadata"]["warnings"])
+
+    def test_unknown_namespace_warns(self, tmp_path):
+        self._setup(tmp_path)
+        result = mcp_server.tool_compare_periods(
+            metric="cpu",
+            namespace="ghost-ns",
+            data_dir=tmp_path,
+        )
+        warnings = result["metadata"]["warnings"]
+        assert any("ghost-ns" in w for w in warnings)
+        # Both blocks present but empty
+        assert result["daily_14d"]["aggregate"] == 0.0
+        assert result["monthly_12m"]["series"] == []
+
+    def test_invalid_metric_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            mcp_server.tool_compare_periods(
+                metric="disk",
+                namespace="x",
+                data_dir=tmp_path,
+            )
+
+
+class TestClassifyTrend:
+    def test_growing_above_threshold(self):
+        assert mcp_server._classify_trend([10.0, 10.0, 12.0, 12.0]) == "growing"
+
+    def test_decreasing_below_threshold(self):
+        assert mcp_server._classify_trend([20.0, 20.0, 10.0, 10.0]) == "decreasing"
+
+    def test_stable_within_threshold(self):
+        # First half mean 10, second 10.5 → delta 5% < 10%
+        assert mcp_server._classify_trend([10.0, 10.0, 10.5, 10.5]) == "stable"
+
+    def test_insufficient_data(self):
+        assert mcp_server._classify_trend([]) == "insufficient_data"
+        assert mcp_server._classify_trend([5.0]) == "insufficient_data"
+
+    def test_zero_baseline_growth(self):
+        assert mcp_server._classify_trend([0.0, 0.0, 5.0, 5.0]) == "growing"
+
+
+# ---------------------------------------------------------------------------
+# Tool: group_namespaces (§4.5)
+# ---------------------------------------------------------------------------
+
+
+def _setup_group_fixture(tmp_path):
+    """Mix of openshift-*, open-cluster-management-*, application, and special.
+
+    Date "02 Feb" usage:
+        openshift-monitoring=40, openshift-nmstate=10, openshift-dns=5
+        open-cluster-management=50, open-cluster-management-agent=20
+        registry=15, my-app=8
+        non-allocatable=100
+    """
+    _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+    _write(
+        tmp_path,
+        "cpu_usage_period_1209600.json",
+        [
+            # 01 Feb — sparse, for "default date = last" test
+            {"stack": "openshift-monitoring", "usage": 30.0, "date": "01 Feb"},
+            {"stack": "registry", "usage": 10.0, "date": "01 Feb"},
+            # 02 Feb — full fixture
+            {"stack": "openshift-monitoring", "usage": 40.0, "date": "02 Feb"},
+            {"stack": "openshift-nmstate", "usage": 10.0, "date": "02 Feb"},
+            {"stack": "openshift-dns", "usage": 5.0, "date": "02 Feb"},
+            {"stack": "open-cluster-management", "usage": 50.0, "date": "02 Feb"},
+            {"stack": "open-cluster-management-agent", "usage": 20.0, "date": "02 Feb"},
+            {"stack": "registry", "usage": 15.0, "date": "02 Feb"},
+            {"stack": "my-app", "usage": 8.0, "date": "02 Feb"},
+            {"stack": "non-allocatable", "usage": 100.0, "date": "02 Feb"},
+        ],
+    )
+
+
+class TestToolGroupNamespaces:
+    def test_openshift_prefix_match(self, tmp_path):
+        _setup_group_fixture(tmp_path)
+        result = mcp_server.tool_group_namespaces(
+            metric="cpu",
+            scale="daily_14d",
+            pattern="openshift-*",
+            data_dir=tmp_path,
+        )
+        # Default date = 02 Feb (last)
+        assert result["date"] == "02 Feb"
+        # openshift-monitoring=40, openshift-nmstate=10, openshift-dns=5
+        assert result["matched_count"] == 3
+        assert result["group_total"] == 55.0
+        names = {m["namespace"] for m in result["members"]}
+        assert names == {"openshift-monitoring", "openshift-nmstate", "openshift-dns"}
+
+    def test_members_sorted_descending(self, tmp_path):
+        _setup_group_fixture(tmp_path)
+        result = mcp_server.tool_group_namespaces(
+            metric="cpu",
+            scale="daily_14d",
+            pattern="openshift-*",
+            data_dir=tmp_path,
+        )
+        values = [m["value"] for m in result["members"]]
+        assert values == sorted(values, reverse=True)
+        # Top is openshift-monitoring=40
+        assert result["members"][0]["namespace"] == "openshift-monitoring"
+        assert result["members"][0]["value"] == 40.0
+
+    def test_pattern_with_star_excludes_special(self, tmp_path):
+        _setup_group_fixture(tmp_path)
+        result = mcp_server.tool_group_namespaces(
+            metric="cpu",
+            scale="daily_14d",
+            pattern="*",
+            data_dir=tmp_path,
+        )
+        names = {m["namespace"] for m in result["members"]}
+        # non-allocatable matches the pattern but is filtered as special
+        assert "non-allocatable" not in names
+        # Group total = 40+10+5+50+20+15+8 = 148 (no overhead 100)
+        assert result["group_total"] == 148.0
+
+    def test_open_cluster_management_pattern(self, tmp_path):
+        _setup_group_fixture(tmp_path)
+        result = mcp_server.tool_group_namespaces(
+            metric="cpu",
+            scale="daily_14d",
+            pattern="open-cluster-management*",
+            data_dir=tmp_path,
+        )
+        assert result["matched_count"] == 2
+        assert result["group_total"] == 70.0  # 50 + 20
+
+    def test_explicit_date_filter(self, tmp_path):
+        _setup_group_fixture(tmp_path)
+        result = mcp_server.tool_group_namespaces(
+            metric="cpu",
+            scale="daily_14d",
+            pattern="openshift-*",
+            date="01 Feb",
+            data_dir=tmp_path,
+        )
+        assert result["date"] == "01 Feb"
+        assert result["matched_count"] == 1
+        assert result["group_total"] == 30.0
+
+    def test_pattern_matches_nothing_warns(self, tmp_path):
+        _setup_group_fixture(tmp_path)
+        result = mcp_server.tool_group_namespaces(
+            metric="cpu",
+            scale="daily_14d",
+            pattern="nope-*",
+            data_dir=tmp_path,
+        )
+        assert result["matched_count"] == 0
+        assert result["group_total"] == 0.0
+        assert result["members"] == []
+        assert any("matched no namespace" in w for w in result["metadata"]["warnings"])
+
+    def test_unknown_date_warns(self, tmp_path):
+        _setup_group_fixture(tmp_path)
+        result = mcp_server.tool_group_namespaces(
+            metric="cpu",
+            scale="daily_14d",
+            pattern="openshift-*",
+            date="99 Dec",
+            data_dir=tmp_path,
+        )
+        # Date used as-is even if not in file → 0 matches + warning
+        assert result["date"] == "99 Dec"
+        assert result["matched_count"] == 0
+        assert any("99 Dec" in w for w in result["metadata"]["warnings"])
+
+    def test_missing_file_returns_empty_with_warning(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        result = mcp_server.tool_group_namespaces(
+            metric="cpu",
+            scale="daily_14d",
+            pattern="openshift-*",
+            data_dir=tmp_path,
+        )
+        assert result["matched_count"] == 0
+        assert result["members"] == []
+        assert any("cpu_usage_period_1209600.json" in w for w in result["metadata"]["warnings"])
+
+    def test_data_window_reflects_single_date(self, tmp_path):
+        _setup_group_fixture(tmp_path)
+        result = mcp_server.tool_group_namespaces(
+            metric="cpu",
+            scale="daily_14d",
+            pattern="openshift-*",
+            data_dir=tmp_path,
+        )
+        window = result["metadata"]["data_window"]
+        assert window["start"] == "02 Feb"
+        assert window["end"] == "02 Feb"
+        assert window["points"] == 1
+
+    def test_empty_pattern_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            mcp_server.tool_group_namespaces(
+                metric="cpu",
+                scale="daily_14d",
+                pattern="",
+                data_dir=tmp_path,
+            )
+
+    def test_invalid_metric_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            mcp_server.tool_group_namespaces(
+                metric="disk",
+                scale="daily_14d",
+                pattern="*",
+                data_dir=tmp_path,
+            )
+
+    def test_invalid_scale_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            mcp_server.tool_group_namespaces(
+                metric="cpu",
+                scale="hourly",
+                pattern="*",
+                data_dir=tmp_path,
+            )
+
+
+# ---------------------------------------------------------------------------
+# MCP wiring smoke tests (§7.2 step 8)
+#
+# These tests are skipped when the ``mcp`` SDK is not installed (e.g. on a
+# Windows dev machine where the project's rrdtool dep prevents ``uv sync``).
+# They cover only the wiring layer — the tool_* logic is tested above.
+# ---------------------------------------------------------------------------
+
+try:
+    import mcp  # noqa: F401  (presence check)
+
+    _MCP_AVAILABLE = True
+except ImportError:
+    _MCP_AVAILABLE = False
+
+
+@pytest.mark.skipif(not _MCP_AVAILABLE, reason="mcp SDK not installed")
+class TestMcpWiring:
+    def test_build_mcp_app_registers_all_tools(self):
+        app = mcp_server._build_mcp_app()
+        registered = {name for name, _ in mcp_server._MCP_TOOL_REGISTRY}
+
+        expected = {
+            "list_namespaces",
+            "describe_dataset",
+            "get_usage",
+            "get_top_consumers",
+            "get_namespace_breakdown",
+            "get_efficiency",
+            "get_timeseries",
+            "compare_periods",
+            "get_efficiency_timeseries",
+            "group_namespaces",
+        }
+        assert registered == expected
+        # FastMCP exposes a list_tools method (or a tools manager) — just
+        # assert the app instance is built and named correctly.
+        assert app is not None
+        assert getattr(app, "name", None) in ("kubeledger-mcp", None) or hasattr(app, "name")
+
+    def test_registry_points_to_actual_tool_functions(self):
+        mcp_server._build_mcp_app()
+        for name, func in mcp_server._MCP_TOOL_REGISTRY:
+            assert callable(func), f"registry entry {name!r} is not callable"
+            # Sanity check: function name matches its key
+            assert func.__name__ == "tool_" + name
+
+    def test_detect_structured_content_reports_a_decision(self):
+        supported, reason = mcp_server.detect_structured_content_support()
+        # Whatever the decision is, the function must return a non-empty
+        # reason string — spec §4.7 requires that the developer be informed.
+        assert isinstance(supported, bool)
+        assert isinstance(reason, str) and reason
+
+
+class TestMcpWiringStubsWithoutSDK:
+    """Verify the module is importable without the mcp SDK."""
+
+    def test_module_imports_without_sdk(self):
+        # mcp_server is already imported at top of file — re-import via a
+        # fresh sys.path manipulation would be heavy; just verify the
+        # public surface still exists.
+        assert callable(mcp_server.tool_list_namespaces)
+        assert callable(mcp_server.tool_describe_dataset)
+        assert callable(mcp_server.tool_get_usage)
+        assert callable(mcp_server.tool_get_top_consumers)
+        assert callable(mcp_server.tool_get_namespace_breakdown)
+        assert callable(mcp_server.tool_get_efficiency)
+        assert callable(mcp_server.tool_get_timeseries)
+        assert callable(mcp_server.tool_compare_periods)
+        assert callable(mcp_server.tool_get_efficiency_timeseries)
+        assert callable(mcp_server.tool_group_namespaces)
+
+    def test_detect_structured_content_handles_missing_sdk_gracefully(self):
+        # Even when the SDK is missing, the detector must return cleanly
+        # rather than raise — wiring code at startup depends on that.
+        result = mcp_server.detect_structured_content_support()
+        assert len(result) == 2
+        assert isinstance(result[0], bool)
+        assert isinstance(result[1], str)
+
+
+# ---------------------------------------------------------------------------
+# Metadata audit (§7.2 step 9) — every tool's response must carry a metadata
+# block whose shape matches spec §4.6.
+#
+# These tests deliberately ignore the *content* of metadata (already covered
+# per-tool above) and focus on:
+#   - presence of every required field,
+#   - correct typing (warnings is a list, timezone is "UTC", ...),
+#   - ISO 8601 UTC formatting of generated_at_utc,
+#   - propagation of caller-supplied warnings.
+# ---------------------------------------------------------------------------
+
+
+METADATA_REQUIRED_KEYS = frozenset(
+    {
+        "cost_model",
+        "currency",
+        "unit",
+        "metric",
+        "scale",
+        "data_window",
+        "source_file",
+        "generated_at_utc",
+        "warnings",
+    }
+)
+
+
+def _assert_valid_metadata(md, label):
+    """Cross-tool metadata invariants — shape + types + UTC."""
+    assert isinstance(md, dict), f"{label}: metadata is not a dict"
+    extra = set(md) - METADATA_REQUIRED_KEYS
+    missing = METADATA_REQUIRED_KEYS - set(md)
+    assert not extra, f"{label}: metadata has unexpected keys {extra}"
+    assert not missing, f"{label}: metadata is missing keys {missing}"
+
+    assert isinstance(md["warnings"], list), f"{label}: warnings is not a list"
+    for w in md["warnings"]:
+        assert isinstance(w, str) and w, f"{label}: warning is not a non-empty string"
+
+    if md["data_window"] is not None:
+        dw = md["data_window"]
+        assert dw["timezone"] == "UTC", f"{label}: data_window.timezone != UTC"
+        assert "granularity" in dw and dw["granularity"] in (
+            "daily",
+            "monthly",
+            "hourly",
+        ), f"{label}: data_window.granularity invalid"
+        assert "points" in dw and isinstance(dw["points"], int), f"{label}: data_window.points is not int"
+
+    if md["generated_at_utc"] is not None:
+        assert md["generated_at_utc"].endswith("Z"), (
+            "{}: generated_at_utc not ISO 8601 UTC (must end with Z): {}".format(
+                label,
+                md["generated_at_utc"],
+            )
+        )
+
+
+def _setup_full_audit_fixture(tmp_path):
+    """Dataset rich enough to drive every tool through a happy path.
+
+    - 2 metrics × 2 scales × usage + requests histograms (8 files)
+    - usage + rf trends for both metrics (4 files)
+    - backend.json with cost_model=cumulative
+    """
+    _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+
+    daily = _make_consolidation_dataset()
+    monthly = [
+        {"stack": "registry", "usage": 20.0, "date": "Dec 2025"},
+        {"stack": "registry", "usage": 25.0, "date": "Jan 2026"},
+        {"stack": "registry", "usage": 30.0, "date": "Feb 2026"},
+        {"stack": "alpha", "usage": 5.0, "date": "Dec 2025"},
+        {"stack": "alpha", "usage": 6.0, "date": "Jan 2026"},
+        {"stack": "alpha", "usage": 8.0, "date": "Feb 2026"},
+        {"stack": "non-allocatable", "usage": 200.0, "date": "Feb 2026"},
+    ]
+
+    for metric in ("cpu", "memory"):
+        for dimension in ("usage", "requests"):
+            _write(
+                tmp_path, "{}_{}_period_1209600.json".format(metric if metric == "cpu" else "memory", dimension), daily
+            )
+            _write(
+                tmp_path,
+                "{}_{}_period_31968000.json".format(metric if metric == "cpu" else "memory", dimension),
+                monthly,
+            )
+        _write(
+            tmp_path,
+            "{}_usage_trends.json".format(metric if metric == "cpu" else "memory"),
+            _make_trends_for_namespace("registry", count=24),
+        )
+        _write(
+            tmp_path,
+            "{}_rf_trends.json".format(metric if metric == "cpu" else "memory"),
+            _make_trends_for_namespace("registry", count=24, base=0.5),
+        )
+
+
+# Tools sorted as in spec §4. Each entry: (name, callable taking data_dir → response).
+ALL_TOOL_INVOCATIONS = [
+    ("list_namespaces", lambda d: mcp_server.tool_list_namespaces(data_dir=d)),
+    ("describe_dataset", lambda d: mcp_server.tool_describe_dataset(data_dir=d)),
+    ("get_usage", lambda d: mcp_server.tool_get_usage(metric="cpu", scale="daily_14d", data_dir=d)),
+    ("get_top_consumers", lambda d: mcp_server.tool_get_top_consumers(metric="cpu", scale="daily_14d", data_dir=d)),
+    (
+        "get_namespace_breakdown",
+        lambda d: mcp_server.tool_get_namespace_breakdown(metric="cpu", scale="daily_14d", data_dir=d),
+    ),
+    ("get_efficiency", lambda d: mcp_server.tool_get_efficiency(scale="daily_14d", data_dir=d)),
+    ("get_timeseries", lambda d: mcp_server.tool_get_timeseries(metric="cpu", namespace="registry", data_dir=d)),
+    ("compare_periods", lambda d: mcp_server.tool_compare_periods(metric="cpu", namespace="registry", data_dir=d)),
+    (
+        "get_efficiency_timeseries",
+        lambda d: mcp_server.tool_get_efficiency_timeseries(metric="cpu", namespace="registry", data_dir=d),
+    ),
+    (
+        "group_namespaces",
+        lambda d: mcp_server.tool_group_namespaces(metric="cpu", scale="daily_14d", pattern="*", data_dir=d),
+    ),
+]
+
+
+class TestMetadataAuditAcrossAllTools:
+    @pytest.mark.parametrize("name,invoke", ALL_TOOL_INVOCATIONS, ids=[n for n, _ in ALL_TOOL_INVOCATIONS])
+    def test_metadata_shape_is_uniform(self, tmp_path, name, invoke):
+        _setup_full_audit_fixture(tmp_path)
+        result = invoke(tmp_path)
+        assert "metadata" in result, f"{name}: response has no metadata key"
+        _assert_valid_metadata(result["metadata"], name)
+
+    @pytest.mark.parametrize("name,invoke", ALL_TOOL_INVOCATIONS, ids=[n for n, _ in ALL_TOOL_INVOCATIONS])
+    def test_metadata_carries_cost_model_when_available(self, tmp_path, name, invoke):
+        _setup_full_audit_fixture(tmp_path)
+        result = invoke(tmp_path)
+        md = result["metadata"]
+        # backend.json is present in the fixture → cost_model & currency populated
+        assert md["cost_model"] == "cumulative", f"{name}: lost cost_model"
+        assert md["currency"] == "%", f"{name}: lost currency"
+        # unit: either the cumulative unit OR the efficiency_ratio override
+        assert md["unit"] in ("percent_of_cluster_capacity", "efficiency_ratio"), "{}: unexpected unit {!r}".format(
+            name, md["unit"]
+        )
+
+    @pytest.mark.parametrize("name,invoke", ALL_TOOL_INVOCATIONS, ids=[n for n, _ in ALL_TOOL_INVOCATIONS])
+    def test_metadata_present_even_when_data_missing(self, tmp_path, name, invoke):
+        # No fixture at all — every tool must still produce a valid metadata
+        # block (with warnings explaining the lack of data).
+        result = invoke(tmp_path)
+        assert "metadata" in result
+        _assert_valid_metadata(result["metadata"], name)
+        assert result["metadata"]["warnings"], f"{name}: empty warnings list while data is missing"
+
+
+class TestFreshnessWarningPropagation:
+    """Spec §7.2-5 — freshness warning kicks in for stale data, on every tool."""
+
+    @pytest.mark.parametrize("name,invoke", ALL_TOOL_INVOCATIONS, ids=[n for n, _ in ALL_TOOL_INVOCATIONS])
+    def test_stale_data_yields_warning(self, tmp_path, name, invoke):
+        _setup_full_audit_fixture(tmp_path)
+        # Push every data file's mtime 2 hours into the past.
+        stale_time = datetime.now(tz=UTC).timestamp() - 2 * 3600
+        for path in tmp_path.iterdir():
+            if path.name == "backend.json":
+                continue  # backend.json is excluded from freshness (spec §7.2-5)
+            os.utime(path, (stale_time, stale_time))
+
+        result = invoke(tmp_path)
+        warnings = result["metadata"]["warnings"]
+        # Some tools (list_namespaces, describe_dataset) read every data file
+        # → freshness applies; trend-only tools also touch files; backend.json
+        # exclusion means the only mtime considered is data → all should warn.
+        assert any("stale data" in w for w in warnings), f"{name}: expected a stale-data warning, got {warnings!r}"
+
+
+class TestWarningsAreActionable:
+    """Warnings must include enough context to be acted upon by the client."""
+
+    def test_missing_file_warning_names_the_file(self, tmp_path):
+        result = mcp_server.tool_get_usage(
+            metric="cpu",
+            scale="daily_14d",
+            data_dir=tmp_path,
+        )
+        warnings = result["metadata"]["warnings"]
+        assert any("cpu_usage_period_1209600.json" in w for w in warnings)
+
+    def test_unknown_namespace_warning_names_the_namespace(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(tmp_path, "cpu_usage_trends.json", _make_trends_for_namespace("real-ns", count=3))
+        result = mcp_server.tool_get_timeseries(
+            metric="cpu",
+            namespace="ghost",
+            data_dir=tmp_path,
+        )
+        warnings = result["metadata"]["warnings"]
+        assert any("ghost" in w for w in warnings)
+
+    def test_efficiency_threshold_warning_names_namespace_and_metric(self, tmp_path):
+        _write(tmp_path, "backend.json", {"cost_model": "cumulative", "currency": "%"})
+        _write(
+            tmp_path,
+            "cpu_usage_period_1209600.json",
+            [
+                {"stack": "weird-ns", "usage": 10.0, "date": "01 Feb"},
+            ],
+        )
+        _write(
+            tmp_path,
+            "cpu_requests_period_1209600.json",
+            [
+                {"stack": "weird-ns", "usage": 1e-9, "date": "01 Feb"},
+            ],
+        )
+        result = mcp_server.tool_get_efficiency(
+            scale="daily_14d",
+            metric="cpu",
+            data_dir=tmp_path,
+        )
+        warnings = result["metadata"]["warnings"]
+        assert any("weird-ns" in w and "cpu" in w for w in warnings)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,37 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -18,6 +49,63 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload-time = "2025-11-12T02:54:51.517Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload-time = "2025-11-12T02:54:49.735Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -99,6 +187,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
 name = "flask"
 version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -126,6 +267,52 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/37/bcfa6c7d5eec777c4c7cf45ce6b27631cebe5230caf88d85eadd63edd37a/flask_cors-6.0.1.tar.gz", hash = "sha256:d81bcb31f07b0985be7f48406247e9243aced229b7747219160a0559edd678db", size = 13463, upload-time = "2025-06-11T01:32:08.518Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/f8/01bf35a3afd734345528f98d0353f2a978a476528ad4d7e78b70c4d149dd/flask_cors-6.0.1-py3-none-any.whl", hash = "sha256:c7b2cbfb1a31aa0d2e5341eea03a6805349f7a61647daee1a15c46bbe981494c", size = 13244, upload-time = "2025-06-11T01:32:07.352Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -168,12 +355,40 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "kubeledger"
-version = "26.1.1"
+version = "26.5.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },
     { name = "flask-cors" },
+    { name = "mcp" },
     { name = "prometheus-client" },
     { name = "requests" },
     { name = "rrdtool" },
@@ -192,11 +407,12 @@ dev = [
 requires-dist = [
     { name = "flask", specifier = ">=3.0.0" },
     { name = "flask-cors", specifier = ">=6.0.0" },
+    { name = "mcp", specifier = ">=1.0" },
     { name = "prometheus-client", specifier = ">=0.20.0" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "rrdtool", specifier = ">=0.1.16" },
     { name = "urllib3", specifier = ">=2.6.3" },
-    { name = "waitress", specifier = ">=3.0.1" },
+    { name = "waitress", specifier = ">=3.0.2" },
     { name = "werkzeug", specifier = ">=3.1.5" },
 ]
 
@@ -270,6 +486,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -297,12 +538,139 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -322,6 +690,54 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -334,6 +750,87 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
 ]
 
 [[package]]
@@ -369,12 +866,72 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b1/8e7077a8641086aea449e1b5752a570f1b5906c64e0a33cd6d93b63a066b/uvicorn-0.47.0.tar.gz", hash = "sha256:7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533", size = 90582, upload-time = "2026-05-14T18:16:54.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl", hash = "sha256:2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432", size = 71301, upload-time = "2026-05-14T18:16:51.762Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add an MCP (Model Context Protocol) server that exposes KubeLedger's static analytics (the JSON files produced by backend.py in `static/data/`) to MCP-aware clients (Claude Desktop, Claude Code, MCP Inspector, agents). Read-only, descriptive only, no LLM, no RRD access.

Ten tools across five groups: Discovery, Consolidations, Efficiency, Trends, Utility. Helm packaging behind a `mcp.enabled` flag, default-on NetworkPolicy covering backend + MCP. Designed to live as a second container in the existing KubeLedger pod, sharing `static/data/` read-only.

Bumps the project version to `26.5.0b1` (PEP 440 normalised — corresponds to KubeLedger 26.5.0-beta1).

### What ships

- **`mcp_server.py`** (~2200 lines, 14 files touched total) — pure-Python tools + FastMCP wiring, single transport: Streamable HTTP at `/mcp`.
- **Helm chart** — second container under `mcp.enabled` (default off), conditional named port `mcp` (8888), new NetworkPolicy template (default on, deny-by-default).
- **Dockerfile** — single line addition (`mcp_server.py` copied alongside `backend.py`).
- **Tests** — 188 tests covering all ten tools, metadata invariants, path-traversal guard, freshness warnings, trend classification, MCP wiring (skipped when SDK absent).
- **CHANGELOG** entry for `v26.5.0b1`.

### Tools exposed

| Group | Tool | Purpose |
|---|---|---|
| Discovery | `list_namespaces`, `describe_dataset` | What's in the dataset, what shapes |
| Consolidations | `get_usage`, `get_top_consumers`, `get_namespace_breakdown` | Per-namespace, rankings, concentration + cluster_overhead |
| Efficiency | `get_efficiency` | Aggregated usage/requests ratio with descriptive classification |
| Trends | `get_timeseries`, `compare_periods`, `get_efficiency_timeseries` | Hourly 7-day series, 14d vs monthly, hourly rf |
| Utility | `group_namespaces` | fnmatch glob aggregation |

### Design decisions

- **Streamable HTTP only** — SSE (legacy, two-endpoint) and stdio (subprocess-spawn) removed. KubeLedger's data lives in-cluster; the natural exposure is HTTP via the pod's Service. The `.mcpb` bundle pattern (which would have required stdio) was considered and dropped — local data snapshots don't match the cluster-generated nature of KubeLedger metrics.
- **No authentication at the tool layer** — replaced by a deny-by-default NetworkPolicy delivered with the chart. Operators MUST configure `networkPolicy.allowedSources` and `mcpAllowedSources` to authorise their clients; empty lists block all ingress (safe failure mode, documented).
- **structuredContent + outputSchema** preferred when SDK supports them, text content fallback otherwise. Detection logged at startup.
- **`Dict[str, Any]` returns** rather than Pydantic models — FastMCP wraps these under `structuredContent.result.*`; text fallback carries the unwrapped spec shape.
- **Defensive coding** — robust JSON parsing (handles backend.py mid-write truncation), `requests < 1e-6` threshold for efficiency (avoids aberrant ratios from infinitesimal aggregates), path-traversal guard in `read_json_file`, fnmatch pattern length cap (256 chars) to prevent ReDoS.

### Known v1 limitation

`billing_hourly_rate` is reported as `null` even when `cost_model=costs`, with an explicit warning. `backend.py` does not currently write the rate into `backend.json` and filters `.billing-hourly-rate` out of histogram dumps, so the value isn't reachable from the static JSON surface. A 3-line backend change would fix this for a follow-up release.

## Deployment

```bash
helm upgrade --install kubeledger ./manifests/kubeledger/helm \
  --set mcp.enabled=true \
  --set "networkPolicy.allowedSources[0].podSelector.matchLabels.app=ui-proxy" \
  --set "networkPolicy.mcpAllowedSources[0].podSelector.matchLabels.app=ui-proxy"
```

The `helm template` rendering toggles cleanly between `mcp.enabled=false` (no `mcp` container, no `mcp` port, no `mcp` NetworkPolicy ingress block) and `mcp.enabled=true` (all three appear).

## Test plan

- [x] `uv run --no-project --with pytest pytest tests/test_mcp_server.py` → 185 pass, 3 skipped (mcp SDK absent in isolated env)
- [x] `uv run --no-project --with pytest --with mcp pytest tests/test_mcp_server.py` → 188 pass
- [x] `uv run --no-project --with ruff ruff check mcp_server.py tests/` → All checks passed
- [x] `podman build -t kubeledger:local .` succeeds
- [x] `podman run --entrypoint python3 ... kubeledger:local -u ./mcp_server.py` starts, logs `transport: streamable-http (endpoint: /mcp)` and `structuredContent: ENABLED`
- [x] End-to-end MCP `initialize` handshake → HTTP 200 from localhost and via portproxy from LAN IP
- [x] Connected from Claude Code via `.mcp.json` (`{"type": "http", "url": "http://localhost:8888/mcp"}`) — 10 tools listed
- [x] Connected from Claude Desktop via `mcp-remote` bridge
- [ ] `helm template kl ./manifests/kubeledger/helm --set mcp.enabled=true` rendering (CI)
- [ ] `helm lint ./manifests/kubeledger/helm` (CI)
- [ ] Deploy on a real OpenShift cluster with OVN-Kubernetes to validate NetworkPolicy enforcement