### PR TITLE
docs(readme): highlight MCP in Overview and Key Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - [Overview](#overview)
 - [Key Features](#key-features)
 - [Quick Start](#quick-start)
-- [MCP Integration (AI Assistant) / Requires v26.05.0+](#mcp-integration-ai-assistant--requires-v26051)
+- [MCP Integration (AI Assistant) / Requires v26.05.0+](#mcp-integration-ai-assistant--requires-v26050)
 - [Architecture](#architecture)
 - [Documentation](#documentation)
 - [Configuration](#configuration)
@@ -31,6 +31,8 @@
 **KubeLedger** is a usage accounting tool that helps organizations track, analyze, and optimize **CPU, Memory, and GPU** resources on Kubernetes clusters over time (hourly, daily, monthly).
 
 It acts as a **System of Record** for your cluster resources, providing insightful usage analytics and charts that engineering and financial teams can use as key indicators for cost optimization decisions.
+
+> **New in v26.05: ask your AI assistant.** KubeLedger ships an optional [Model Context Protocol (MCP) server](#mcp-integration-ai-assistant--requires-v26050) that exposes the same analytics to AI tools such as Claude, Gemini, Mistral, Cursor, Windsurf, MCP Inspector and other MCP-aware clients. Ten read-only tools let an assistant rank consumers, group namespaces, assess efficiency or compare periods in plain language, unlocking investigations beyond what predefined dashboards can show.
 
 ### Tracked Resources
 
@@ -52,6 +54,7 @@ It acts as a **System of Record** for your cluster resources, providing insightf
 | **Usage Efficiency Analysis** | Compare resource requests against actual usage to identify over/under-provisioning |
 | **Cost Allocation & Chargeback** | Automatic resource usage accounting per namespace for billing and showback |
 | **Prometheus Integration** | Native exporter at `/metrics` for Grafana dashboards and alerting |
+| **AI Assistant Integration (MCP)** | **New in v26.05.** Read-only Model Context Protocol server: AI tools such as Claude, Gemini, Mistral and Cursor query usage, efficiency, trends and rankings in plain language through ten read-only tools |
 
 ## Quick Start
 
@@ -162,7 +165,7 @@ kubectl port-forward svc/kubeledger 5483:80 -n kubeledger
 
 ## MCP Integration (AI Assistant) / Requires v26.05.0+
 
-KubeLedger ships with an **optional MCP ([Model Context Protocol](https://modelcontextprotocol.io)) server** that gives MCP-aware AI tools **direct access to the underlying analytics data**: the consolidated CPU, memory and GPU usage that the web UI is built on. MCP is an open standard adopted by a growing ecosystem: Anthropic's Claude Desktop and Claude Code, Google's Gemini CLI, IDE assistants such as Cursor, Windsurf and Cline, the MCP Inspector developer tool, and others.
+KubeLedger ships with an **optional MCP ([Model Context Protocol](https://modelcontextprotocol.io)) server** that gives MCP-aware AI tools **direct access to the underlying analytics data**: the consolidated CPU, memory and GPU usage that the web UI is built on. MCP is an open standard adopted by a growing ecosystem: Anthropic's Claude Desktop and Claude Code, Google's Gemini CLI, Mistral's Le Chat, IDE assistants such as Cursor, Windsurf and Cline, the MCP Inspector developer tool, and others.
 
 Where the UI renders a fixed set of dashboards, the MCP exposes ten read-only tools that let an AI assistant combine, filter and aggregate this data into **custom rankings, namespace groupings, efficiency assessments, trend comparisons and narrative insights**, i.e. analyses the UI does not predefine.
 
@@ -325,7 +328,7 @@ The assistant picks the right tool automatically. Ask in plain language:
 3. Data is consolidated into hourly, daily, and monthly aggregates
 4. `dump_analytics` periodically writes the aggregates as JSON files into a shared volume
 5. The Flask API serves the data to the built-in web UI and Prometheus scraper
-6. *(optional)* The MCP container reads the same JSON files **read-only** and exposes them as 10 MCP tools to AI assistants. See [MCP Integration](#mcp-integration-ai-assistant)
+6. *(optional)* The MCP container reads the same JSON files **read-only** and exposes them as 10 MCP tools to AI assistants. See [MCP Integration](#mcp-integration-ai-assistant--requires-v26050)
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- Adds a **New in v26.05** callout in the Overview, pointing readers to the MCP Integration section
- Adds an **AI Assistant Integration (MCP)** row at the end of the Key Features table
- Mentions **Mistral** alongside Claude, Gemini, Cursor and other MCP-aware tools in the inline lists (Overview callout, Key Features row, MCP Integration section intro)
- Fixes two stale anchors that pointed at the v26.05.1 heading after the release was renamed back to v26.05.0 on `main`

## Why

The current Overview and Key Features sections introduce KubeLedger as a usage accounting tool with dashboards and Prometheus integration, but the new MCP server is only discoverable by scrolling to its dedicated section. Surfacing it at the top of the README increases visibility for first-time visitors. The callout uses the same `>` style as the existing 'Multi-cluster Integration' note in Overview, so the visual convention stays consistent. The Key Features row uses a `**New in v26.05.**` prefix to signal recency without breaking the table's existing reading order.

## Out of scope

The 'Other MCP clients' sub-section (which gives client-specific configuration snippets) is **not** touched. Adding Mistral Le Chat there requires a verified configuration example (config path, JSON schema) that is not provided here. Happy to add it in a follow-up once the format is confirmed.

## Test plan

- [x] No em-dashes introduced in the new content
- [x] Anchor `#mcp-integration-ai-assistant--requires-v26050` matches the current section heading `## MCP Integration (AI Assistant) / Requires v26.05.0+`
- [ ] Render preview on GitHub once pushed